### PR TITLE
Fix URL to truseq document

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ See also the section about paired-end adapter trimming above.
 
 The adapter sequences can be found in the document [Illumina TruSeq Adapters De-Mystified][1].
 
-[1]: http://genomics.med.tufts.edu/documents/protocols/TUCF_Understanding_Illumina_TruSeq_Adapters.pdf
+[1]: http://tucf-genomics.tufts.edu/documents/protocols/TUCF_Understanding_Illumina_TruSeq_Adapters.pdf
 
 
 Adapters


### PR DESCRIPTION
The original [link](http://genomics.med.tufts.edu/documents/protocols/TUCF_Understanding_Illumina_TruSeq_Adapters.pdf) to "Illumina TruSeq Adapters De-Mystified" has been expired. 

It can be replaced with the [link](http://tucf-genomics.tufts.edu/documents/protocols/TUCF_Understanding_Illumina_TruSeq_Adapters.pdf) still hosted by the same institution (TUCF-Genomics).
