### PR TITLE
Remove buffer_size parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cutadapt/*.so
 doc/_build
 *.pyo
 .idea/
+tests/testtmp/*
+*.fastq

--- a/cutadapt/_seqio.pyx
+++ b/cutadapt/_seqio.pyx
@@ -4,6 +4,7 @@ from __future__ import print_function, division, absolute_import
 from .xopen import xopen
 from .seqio import _shorten, FormatError, SequenceReader
 
+
 cdef class Sequence(object):
 	"""
 	A record in a FASTQ file. Also used for FASTA (then the qualities attribute

--- a/cutadapt/_seqio.pyx
+++ b/cutadapt/_seqio.pyx
@@ -1,12 +1,8 @@
 # kate: syntax Python;
 # cython: profile=False
 from __future__ import print_function, division, absolute_import
-
-import io
-
 from .xopen import xopen
 from .seqio import _shorten, FormatError, SequenceReader
-
 
 cdef class Sequence(object):
 	"""
@@ -54,7 +50,8 @@ cdef class Sequence(object):
 		qstr = ''
 		if self.qualities is not None:
 			qstr = ', qualities={0!r}'.format(_shorten(self.qualities))
-		return '<Sequence(name={0!r}, sequence={1!r}{2})>'.format(_shorten(self.name), _shorten(self.sequence), qstr)
+		return '<Sequence(name={0!r}, sequence={1!r}{2})>'.format(
+			_shorten(self.name), _shorten(self.sequence), qstr)
 
 	def __len__(self):
 		return len(self.sequence)
@@ -79,12 +76,12 @@ class FastqReader(SequenceReader):
 	"""
 	Reader for FASTQ files. Does not support multi-line FASTQ files.
 	"""
-	def __init__(self, file, sequence_class=Sequence, buffer_size=io.DEFAULT_BUFFER_SIZE):
+	def __init__(self, file, sequence_class=Sequence):
 		"""
 		file is a filename or a file-like object.
 		If file is a filename, then .gz files are supported.
 		"""
-		super(FastqReader, self).__init__(file, buffer_size=buffer_size)
+		super(FastqReader, self).__init__(file)
 		self.sequence_class = sequence_class
 		self.delivers_qualities = True
 
@@ -100,7 +97,8 @@ class FastqReader(SequenceReader):
 		it = iter(self._file)
 		line = next(it)
 		if not (line and line[0] == '@'):
-			raise FormatError("Line {0} in FASTQ file is expected to start with '@', but found {1!r}".format(i+1, line[:10]))
+			raise FormatError("Line {0} in FASTQ file is expected to start with '@', ",
+				"but found {1!r}".format(i+1, line[:10]))
 		strip = -2 if line.endswith('\r\n') else -1
 		name = line[1:strip]
 
@@ -108,7 +106,8 @@ class FastqReader(SequenceReader):
 		for line in it:
 			if i == 0:
 				if not (line and line[0] == '@'):
-					raise FormatError("Line {0} in FASTQ file is expected to start with '@', but found {1!r}".format(i+1, line[:10]))
+					raise FormatError("Line {0} in FASTQ file is expected to start with '@', "
+						"but found {1!r}".format(i+1, line[:10]))
 				name = line[1:strip]
 			elif i == 1:
 				sequence = line[:strip]
@@ -118,7 +117,8 @@ class FastqReader(SequenceReader):
 				else:
 					line = line[:strip]
 					if not (line and line[0] == '+'):
-						raise FormatError("Line {0} in FASTQ file is expected to start with '+', but found {1!r}".format(i+1, line[:10]))
+						raise FormatError("Line {0} in FASTQ file is expected to start with '+', "
+							"but found {1!r}".format(i+1, line[:10]))
 					if len(line) > 1:
 						if not line[1:] == name:
 							raise FormatError(

--- a/cutadapt/compat.py
+++ b/cutadapt/compat.py
@@ -5,7 +5,11 @@ Minimal Py2/Py3 compatibility library.
 from __future__ import print_function, division, absolute_import
 import sys
 PY3 = sys.version > '3'
-
+# The io module was introduced in py26, so unless
+# there's some py26 performance problem I don't
+# know about, this should change to:
+# PY26 = sys.version_info >= (2, 6)
+PY27 = sys.version_info >= (2, 7)
 
 if PY3:
 	maketrans = str.maketrans
@@ -25,8 +29,18 @@ if PY3:
 		else:
 			return s
 	from io import StringIO
+	import io
+	fopen = io.open
 
 else:
+	if PY27:
+		# In python 2.7 (and probably 2.6?), io.read is substantially more efficient 
+		# than the read method on the default file object.
+		import io
+		fopen = io.open
+	else:
+		fopen = open
+	
 	def bytes_to_str(s):
 		return s
 

--- a/cutadapt/compat.py
+++ b/cutadapt/compat.py
@@ -25,18 +25,8 @@ if PY3:
 		else:
 			return s
 	from io import StringIO
-	import io
-	fopen = io.open
 	
 else:
-	if PY27:
-		# In python 2.7 (and probably 2.6?), io.read is substantially more efficient 
-		# than the read method on the default file object.
-		import io
-		fopen = io.open
-	else:
-		fopen = open
-		
 	def bytes_to_str(s):
 		return s
 

--- a/cutadapt/compat.py
+++ b/cutadapt/compat.py
@@ -5,7 +5,7 @@ Minimal Py2/Py3 compatibility library.
 from __future__ import print_function, division, absolute_import
 import sys
 PY3 = sys.version > '3'
-
+PY27 = sys.version_info >= (2, 7)
 
 if PY3:
 	maketrans = str.maketrans
@@ -25,8 +25,18 @@ if PY3:
 		else:
 			return s
 	from io import StringIO
-
+	import io
+	fopen = io.open
+	
 else:
+	if PY27:
+		# In python 2.7 (and probably 2.6?), io.read is substantially more efficient 
+		# than the read method on the default file object.
+		import io
+		fopen = io.open
+	else:
+		fopen = open
+		
 	def bytes_to_str(s):
 		return s
 

--- a/cutadapt/compat.py
+++ b/cutadapt/compat.py
@@ -6,6 +6,7 @@ from __future__ import print_function, division, absolute_import
 import sys
 PY3 = sys.version > '3'
 
+
 if PY3:
 	maketrans = str.maketrans
 	basestring = str
@@ -24,6 +25,7 @@ if PY3:
 		else:
 			return s
 	from io import StringIO
+
 else:
 	def bytes_to_str(s):
 		return s

--- a/cutadapt/compat.py
+++ b/cutadapt/compat.py
@@ -5,7 +5,6 @@ Minimal Py2/Py3 compatibility library.
 from __future__ import print_function, division, absolute_import
 import sys
 PY3 = sys.version > '3'
-PY27 = sys.version_info >= (2, 7)
 
 if PY3:
 	maketrans = str.maketrans
@@ -25,7 +24,6 @@ if PY3:
 		else:
 			return s
 	from io import StringIO
-	
 else:
 	def bytes_to_str(s):
 		return s

--- a/cutadapt/xopen.py
+++ b/cutadapt/xopen.py
@@ -9,7 +9,7 @@ import sys
 import io
 import os
 from subprocess import Popen, PIPE
-from .compat import PY3, basestring
+from .compat import PY3, PY27, fopen, basestring
 
 try:
 	import bz2
@@ -21,17 +21,19 @@ try:
 except ImportError:
 	lzma = None
 
-if sys.version_info < (2, 7):
-	buffered_reader = lambda x: x
-	buffered_writer = lambda x: x
-else:
+# See note in compat.py - I think this should
+# change to PY26
+if PY27:
 	buffered_reader = io.BufferedReader
 	buffered_writer = io.BufferedWriter
+else:
+	buffered_reader = lambda x: x
+	buffered_writer = lambda x: x
 	
 class GzipWriter:
 	def __init__(self, path, mode='w'):
-		self.outfile = open(path, mode)
-		self.devnull = open(os.devnull, 'w')
+		self.outfile = fopen(path, mode)
+		self.devnull = fopen(os.devnull, 'w')
 		try:
 			# Setting close_fds to True is necessary due to
 			# http://bugs.python.org/issue12786
@@ -183,4 +185,4 @@ def xopen(filename, mode='r'):
 				except IOError:
 					return buffered_writer(gzip.open(filename, mode))
 	else:
-		return open(filename, mode)
+		return fopen(filename, mode)

--- a/cutadapt/xopen.py
+++ b/cutadapt/xopen.py
@@ -9,7 +9,7 @@ import sys
 import io
 import os
 from subprocess import Popen, PIPE
-from .compat import PY3, PY27, fopen, basestring
+from .compat import PY3, basestring
 
 try:
 	import bz2
@@ -21,21 +21,17 @@ try:
 except ImportError:
 	lzma = None
 
-# I don't understand this - the io module was introduced
-# in py26, so shouldn't we be using BufferedReader/BufferedWriter
-# unless version < (2, 6)?
-#if compat.PY26:
-if PY27:
-	buffered_reader = io.BufferedReader
-	buffered_writer = io.BufferedWriter
-else:
+if sys.version_info < (2, 7):
 	buffered_reader = lambda x: x
 	buffered_writer = lambda x: x
-
+else:
+	buffered_reader = io.BufferedReader
+	buffered_writer = io.BufferedWriter
+	
 class GzipWriter:
 	def __init__(self, path, mode='w'):
-		self.outfile = fopen(path, mode)
-		self.devnull = fopen(os.devnull, 'w')
+		self.outfile = open(path, mode)
+		self.devnull = open(os.devnull, 'w')
 		try:
 			# Setting close_fds to True is necessary due to
 			# http://bugs.python.org/issue12786
@@ -187,4 +183,4 @@ def xopen(filename, mode='r'):
 				except IOError:
 					return buffered_writer(gzip.open(filename, mode))
 	else:
-		return fopen(filename, mode)
+		return open(filename, mode)


### PR DESCRIPTION
I did some performance testing with buffer_size. It can make a difference on performance, but it's really tricky and system specific. For example, using a larger buffer size can make a difference when disk seek time is slow, but with a SSD using a larger buffer size can make performance worse. And when it does make an improvement, it's not very big. So I removed the buffer_size parameter.