### PR TITLE
Store match_info in read, in preparation for moving I/O out of AdapterCutter

### DIFF
--- a/cutadapt/adapters.py
+++ b/cutadapt/adapters.py
@@ -218,7 +218,30 @@ class Match(object):
 			return self.read.sequence[:self.rstart]
 		else:
 			return self.read.sequence[self.rstop:]
-
+	
+	def get_info_record(self):
+		seq = self.read.sequence
+		qualities = self.read.qualities
+		info = (
+			self.read.name,
+			self.errors,
+			self.rstart,
+			self.rstop,
+			seq[0:self.rstart],
+			seq[self.rstart:self.rstop],
+			seq[self.rstop:],
+			self.adapter.name
+		)
+		if qualities:
+			info += (
+				qualities[0:self.rstart],
+				qualities[self.rstart:self.rstop],
+				qualities[self.rstop:]
+			)
+		else:
+			info += ('','','')
+		
+		return info
 
 def _generate_adapter_name(_start=[1]):
 	name = str(_start[0])

--- a/tests/testadapters.py
+++ b/tests/testadapters.py
@@ -95,3 +95,31 @@ def test_linked_adapter():
 	trimmed = linked_adapter.trimmed(match)
 	assert trimmed.name == 'seq'
 	assert trimmed.sequence == 'CCCCC'
+
+
+def test_info_record():
+	adapter = Adapter(
+		sequence='GAACTCCAGTCACNNNNN',
+		where=BACK,
+		max_error_rate=0.12,
+		min_overlap=5,
+		read_wildcards=False,
+		adapter_wildcards=True,
+		name="Foo")
+	read = Sequence(name="abc", sequence='CCCCAGAACTACAGTCCCGGC')
+	am = Match(astart=0, astop=17, rstart=5, rstop=21, matches=15, errors=2, front=None, 
+		adapter=adapter, read=read)
+	print(am.get_info_record())
+	assert am.get_info_record() == (
+		"abc",
+		2,
+		5,
+		21,
+		'CCCCA',
+		'GAACTACAGTCCCGGC',
+		'',
+		'Foo',
+		'', 
+		'', 
+		''
+	)


### PR DESCRIPTION
* Moved code to create match info tuple to Match.get_info_record() (with test)
* In AdapterCutter.__call__, read.match_info is set by calling Match.get_info_record()
* In AdatperCutter._write_info, match info is retrieved from read.match_info