### PR TITLE
Use Modifiers class to create and manage modifiers; refer to modifiers by name

### DIFF
--- a/cutadapt/modifiers.py
+++ b/cutadapt/modifiers.py
@@ -273,3 +273,36 @@ class NEndTrimmer(object):
 		start_cut = start_cut.end() if start_cut else 0
 		end_cut = end_cut.start() if end_cut else len(read)
 		return read[start_cut:end_cut]
+
+
+class _ModType(dict):
+	"""
+	Enumeration of modifier types.
+	
+	This is an enum-like class that is compatible with python 2x. 
+	This class is only meant to be instantiated once, below (this 
+	would be an anonymous class, if python allowed such a thing).
+	"""
+	def __init__(self):
+		super(_ModType, self).__init__(
+			ADAPTER					= AdapterCutter,
+			CUT						= UnconditionalCutter,
+			LENGTH_TAG				= LengthTagModifier,
+			REMOVE_SUFFIX			= SuffixRemover,
+			ADD_PREFIX_SUFFIX		= PrefixSuffixAdder,
+			ZERO_CAP				= ZeroCapper,
+			TRIM_QUAL				= QualityTrimmer,
+			TRIM_NEXTSEQ_QUAL		= NextseqQualityTrimmer,
+			CS_DOUBLE_ENCODE		= DoubleEncoder,
+			CS_TRIM_PRIMER			= PrimerTrimmer,
+			TRIM_END_N				= NEndTrimmer
+		)
+	
+	def create_modifier(self, mod_type, *args, **kwargs):
+		return self[mod_type](*args, **kwargs)
+	
+	def __getattr__(self, name):
+		assert name in self
+		return name
+
+ModType = _ModType()

--- a/cutadapt/modifiers.py
+++ b/cutadapt/modifiers.py
@@ -277,10 +277,9 @@ class NEndTrimmer(object):
 
 
 class Modifiers(object):
-	def __init__(self, paired):
+	def __init__(self):
 		self.mod1 = OrderedDict()
 		self.mod2 = OrderedDict()
-		self.paired = paired
 	
 	def add_modifier(self, mod_type, read=1, **kwargs):
 		mod = ModType.create_modifier(mod_type, **kwargs)

--- a/cutadapt/modifiers.py
+++ b/cutadapt/modifiers.py
@@ -10,7 +10,6 @@ import re
 from cutadapt.qualtrim import quality_trim_index, nextseq_trim_index
 from cutadapt.compat import maketrans
 
-
 class AdapterCutter(object):
 	"""
 	Repeatedly find one of multiple adapters in reads.
@@ -227,12 +226,13 @@ class ZeroCapper(object):
 		read.qualities = read.qualities.translate(self.zero_cap_trans)
 		return read
 
-
-def PrimerTrimmer(read):
-	"""Trim primer base from colorspace reads"""
-	read = read[1:]
-	read.primer = ''
-	return read
+class primer_trimmer(object):
+	def __call__(self, read):
+		"""Trim primer base from colorspace reads"""
+		read = read[1:]
+		read.primer = ''
+		return read
+PrimerTrimmer=primer_trimmer()
 
 
 class NextseqQualityTrimmer(object):
@@ -294,7 +294,7 @@ class _ModType(dict):
 			TRIM_QUAL				= QualityTrimmer,
 			TRIM_NEXTSEQ_QUAL		= NextseqQualityTrimmer,
 			CS_DOUBLE_ENCODE		= DoubleEncoder,
-			CS_TRIM_PRIMER			= PrimerTrimmer,
+			CS_TRIM_PRIMER			= primer_trimmer,
 			TRIM_END_N				= NEndTrimmer
 		)
 	

--- a/cutadapt/modifiers.py
+++ b/cutadapt/modifiers.py
@@ -146,14 +146,15 @@ class UnconditionalCutter(object):
 	If the length is positive, the bases are removed from the beginning of the read.
 	If the length is negative, the bases are removed from the end of the read.
 	"""
-	def __init__(self, length):
-		self.length = length
+	def __init__(self, lengths):
+		self.beg_length = sum(l for l in lengths if l > 0)
+		self.end_length = sum(l for l in lengths if l < 0)
 
 	def __call__(self, read):
-		if self.length > 0:
-			return read[self.length:]
-		elif self.length < 0:
-			return read[:self.length]
+		if self.end_length < 0:
+			return read[self.beg_length:self.end_length]
+		else:
+			return read[self.beg_length:]
 
 
 class LengthTagModifier(object):
@@ -175,13 +176,16 @@ class SuffixRemover(object):
 	"""
 	Remove a given suffix from read names.
 	"""
-	def __init__(self, suffix):
-		self.suffix = suffix
+	def __init__(self, suffixes):
+		self.suffixes = suffixes
 
 	def __call__(self, read):
+		name = read.name
+		for s in self.suffixes:
+			if name.endswith(s):
+				name = name[:-len(s)]
 		read = read[:]
-		if read.name.endswith(self.suffix):
-			read.name = read.name[:-len(self.suffix)]
+		read.name = name
 		return read
 
 
@@ -227,13 +231,12 @@ class ZeroCapper(object):
 		read.qualities = read.qualities.translate(self.zero_cap_trans)
 		return read
 
-class primer_trimmer(object):
+class PrimerTrimmer(object):
 	def __call__(self, read):
 		"""Trim primer base from colorspace reads"""
 		read = read[1:]
 		read.primer = ''
 		return read
-PrimerTrimmer=primer_trimmer()
 
 
 class NextseqQualityTrimmer(object):
@@ -318,7 +321,7 @@ class _ModType(dict):
 			TRIM_QUAL				= QualityTrimmer,
 			TRIM_NEXTSEQ_QUAL		= NextseqQualityTrimmer,
 			CS_DOUBLE_ENCODE		= DoubleEncoder,
-			CS_TRIM_PRIMER			= primer_trimmer,
+			CS_TRIM_PRIMER			= PrimerTrimmer,
 			TRIM_END_N				= NEndTrimmer
 		)
 	

--- a/cutadapt/report.py
+++ b/cutadapt/report.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 import textwrap
 from .adapters import BACK, FRONT, PREFIX, SUFFIX, ANYWHERE, LINKED
-from .modifiers import QualityTrimmer, AdapterCutter
+from .modifiers import ModType
 from .filters import (NoFilter, PairedNoFilter, TooShortReadFilter, TooLongReadFilter,
 	DiscardTrimmedFilter, DiscardUntrimmedFilter, Demultiplexer, NContentFilter)
 
@@ -31,7 +31,7 @@ class Statistics:
 			self.total_bp2 = total_bp2
 			self.total_bp += total_bp2
 
-	def collect(self, adapters_pair, time, modifiers, modifiers2, writers):
+	def collect(self, adapters_pair, time, modifiers, writers):
 		self.time = max(time, 0.01)
 		self.too_short = None
 		self.too_long = None
@@ -57,13 +57,13 @@ class Statistics:
 		self.with_adapters = [0, 0]
 		self.quality_trimmed_bp = [0, 0]
 		self.did_quality_trimming = False
-		for i, modifiers_list in [(0, modifiers), (1, modifiers2)]:
-			for modifier in modifiers_list:
-				if isinstance(modifier, QualityTrimmer):
-					self.quality_trimmed_bp[i] = modifier.trimmed_bases
-					self.did_quality_trimming = True
-				elif isinstance(modifier, AdapterCutter):
-					self.with_adapters[i] += modifier.with_adapters
+		for i, mod_dict in [(0, modifiers.mod1), (1, modifiers.mod2)]:
+			if ModType.TRIM_QUAL in mod_dict:
+				modifier = mod_dict[ModType.TRIM_QUAL]
+				self.quality_trimmed_bp[i] = modifier.trimmed_bases
+				self.did_quality_trimming = True
+			if ModType.ADAPTER in mod_dict:
+				self.with_adapters[i] += mod_dict[ModType.ADAPTER].with_adapters
 		self.with_adapters_fraction = [ (v / self.n if self.n > 0 else 0) for v in self.with_adapters ]
 		self.quality_trimmed = sum(self.quality_trimmed_bp)
 		self.quality_trimmed_fraction = self.quality_trimmed / self.total_bp if self.total_bp > 0 else 0.0

--- a/tests/testmodifiers.py
+++ b/tests/testmodifiers.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division, absolute_import
 
 from cutadapt.seqio import Sequence
-from cutadapt.modifiers import UnconditionalCutter, NEndTrimmer, QualityTrimmer
+from cutadapt.modifiers import ModType, UnconditionalCutter, NEndTrimmer, QualityTrimmer
 
 def test_unconditional_cutter():
 	uc = UnconditionalCutter(length=5)

--- a/tests/testmodifiers.py
+++ b/tests/testmodifiers.py
@@ -34,3 +34,10 @@ def test_quality_trimmer():
 
 	qt = QualityTrimmer(10, 0, 33)
 	assert qt(read) == Sequence('read1', 'GTTTACGTA', '456789###')
+
+
+def test_mod_type():
+	assert ModType.ADAPTER == "ADAPTER"
+	assert ModType[ModType.CUT] == UnconditionalCutter
+	uc = ModType.create_modifier(ModType.CUT, length=2)
+	assert uc.__class__ == UnconditionalCutter

--- a/tests/testmodifiers.py
+++ b/tests/testmodifiers.py
@@ -5,12 +5,12 @@ from cutadapt.seqio import Sequence
 from cutadapt.modifiers import ModType, Modifiers, UnconditionalCutter, NEndTrimmer, QualityTrimmer
 
 def test_unconditional_cutter():
-	uc = UnconditionalCutter(length=5)
+	uc = UnconditionalCutter(lengths=[5])
 	s = 'abcdefg'
-	assert UnconditionalCutter(length=2)(s) == 'cdefg'
-	assert UnconditionalCutter(length=-2)(s) == 'abcde'
-	assert UnconditionalCutter(length=100)(s) == ''
-	assert UnconditionalCutter(length=-100)(s) == ''
+	assert UnconditionalCutter(lengths=[2])(s) == 'cdefg'
+	assert UnconditionalCutter(lengths=[-2])(s) == 'abcde'
+	assert UnconditionalCutter(lengths=[100])(s) == ''
+	assert UnconditionalCutter(lengths=[-100])(s) == ''
 
 
 def test_nend_trimmer():
@@ -39,13 +39,13 @@ def test_quality_trimmer():
 def test_mod_type():
 	assert ModType.ADAPTER == "ADAPTER"
 	assert ModType[ModType.CUT] == UnconditionalCutter
-	uc = ModType.create_modifier(ModType.CUT, length=2)
+	uc = ModType.create_modifier(ModType.CUT, lengths=[2])
 	assert uc.__class__ == UnconditionalCutter
 
 
 def test_Modifiers_single():
 	m = Modifiers()
-	m.add_modifier(ModType.CUT, length=5)
+	m.add_modifier(ModType.CUT, lengths=[5])
 	assert len(m.mod1) == 1
 	assert list(m.mod1.keys())[0] == ModType.CUT
 	assert list(m.mod1.values())[0].__class__ == UnconditionalCutter
@@ -65,7 +65,7 @@ def test_Modifiers_single():
 
 def test_Modifiers_paired_both():
 	m = Modifiers()
-	m.add_modifier(ModType.CUT, read=1|2, length=5)
+	m.add_modifier(ModType.CUT, read=1|2, lengths=[5])
 	assert len(m.mod1) == 1
 	assert len(m.mod2) == 1
 	assert list(m.mod1.keys())[0] == list(m.mod2.keys())[0] == ModType.CUT

--- a/tests/testmodifiers.py
+++ b/tests/testmodifiers.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division, absolute_import
 
 from cutadapt.seqio import Sequence
-from cutadapt.modifiers import ModType, UnconditionalCutter, NEndTrimmer, QualityTrimmer
+from cutadapt.modifiers import ModType, Modifiers, UnconditionalCutter, NEndTrimmer, QualityTrimmer
 
 def test_unconditional_cutter():
 	uc = UnconditionalCutter(length=5)
@@ -41,3 +41,37 @@ def test_mod_type():
 	assert ModType[ModType.CUT] == UnconditionalCutter
 	uc = ModType.create_modifier(ModType.CUT, length=2)
 	assert uc.__class__ == UnconditionalCutter
+
+
+def test_Modifiers_single():
+	m = Modifiers()
+	m.add_modifier(ModType.CUT, length=5)
+	assert len(m.mod1) == 1
+	assert list(m.mod1.keys())[0] == ModType.CUT
+	assert list(m.mod1.values())[0].__class__ == UnconditionalCutter
+	assert len(m.mod2) == 0
+	
+	# test single-end
+	read = Sequence('read1', 'ACGTTTACGTA', '##456789###')
+	mod_read = m.modify(read)
+	assert mod_read.sequence == 'TACGTA'
+	
+	# test legacy paired-end
+	read2 = Sequence('read1', 'ACGTTTACGTA', '##456789###')
+	mod_read, mod_read2 = m.modify(read, read2)
+	assert mod_read.sequence == 'TACGTA'
+	assert mod_read2.sequence == 'ACGTTTACGTA'
+
+
+def test_Modifiers_paired_both():
+	m = Modifiers()
+	m.add_modifier(ModType.CUT, read=1|2, length=5)
+	assert len(m.mod1) == 1
+	assert len(m.mod2) == 1
+	assert list(m.mod1.keys())[0] == list(m.mod2.keys())[0] == ModType.CUT
+	assert list(m.mod1.values())[0].__class__ == list(m.mod2.values())[0].__class__  == UnconditionalCutter
+	read = Sequence('read1', 'ACGTTTACGTA', '##456789###')
+	read2 = Sequence('read1', 'ACGTTTACGTA', '##456789###')
+	mod_read, mod_read2 = m.modify(read, read2)
+	assert mod_read.sequence == 'TACGTA'
+	assert mod_read2.sequence == 'TACGTA'

--- a/tests/testtrim.py
+++ b/tests/testtrim.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 
 from cutadapt.seqio import ColorspaceSequence, Sequence
 from cutadapt.adapters import Adapter, ColorspaceAdapter, PREFIX, BACK
-from cutadapt.scripts.cutadapt import AdapterCutter
+from cutadapt.modifiers import AdapterCutter
 
 def test_cs_5p():
 	read = ColorspaceSequence("name", "0123", "DEFG", "T")


### PR DESCRIPTION
Transition to using modifier names to refer to modifiers, and a Modifers class to manage modifiers.
* In modifiers.py:
    * Add ModType enum (an emulation of a py35 enum that is py2x compatible)
    * Add Modifiers class that creates modifiers and executes the modification loop
    * Change UnconditionalCutter and SuffixRemover to operate on lists of lengths/suffixes, so that only one modifier of each type needs to be created
    * Make PrimerTrimmer a class
    * Added several tests in test_modifiers.py
* In cutadapt.py:
    * Move modifier creation code to separate method (signature is ugly right now, but will be cleaned up once file writing code is separated from modifiers/filters)
    * Use Modifiers class to create modifiers and perform modification of reads
* In report.py:
    * Needed to change the collect() method to work with a Modifiers object