### PR TITLE
shorten reads: also allow to keep only the end of the reads

### DIFF
--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -206,7 +206,8 @@ def get_option_parser():
 			"+ QUALITY_BASE). This needs to be set to 64 for some old Illumina "
 			"FASTQ files. Default: %default")
 	group.add_option("--length", "-l", type=int, default=None, metavar="LENGTH",
-			help="Shorten reads to LENGTH. This and the following modifications "
+			help="Shorten reads to LENGTH. Positive values remove bases at the end "
+			"while negative ones remove bases at the beginning. This and the following modifications "
 			"are applied after adapter trimming.")
 	group.add_option("--trim-n", action='store_true', default=False,
 		help="Trim N's on ends of reads.")

--- a/src/cutadapt/modifiers.py
+++ b/src/cutadapt/modifiers.py
@@ -233,12 +233,19 @@ class QualityTrimmer(object):
 
 
 class Shortener(object):
-	"""Unconditionally shorten a read to the given length"""
+	"""Unconditionally shorten a read to the given length
+
+	If the length is positive, the bases are removed from the end of the read.
+	If the length is negative, the bases are removed from the beginning of the read.
+	"""
 	def __init__(self, length):
 		self.length = length
 
 	def __call__(self, read):
-		return read[:self.length]
+		if self.length >= 0:
+			return read[:self.length]
+		elif self.length < 0:
+			return read[self.length:]
 
 
 class NEndTrimmer(object):


### PR DESCRIPTION
I have some Ion Torrent reads that were generated using polyA priming. 
I want to remove the polyA tails and then shorten the reads to a maximal length (and keep the end of the reads).

Currently the --length parameter keeps the beginning of the reads when a positive value is given. If a negative value is given, it behaves like the UnconditionalCutter modifier.

This little path changes that behavior.
