### PR TITLE
Add command line flag for output compression.

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -161,10 +161,10 @@ Speed-up tricks
 
 There are several tricks for limiting wall-clock time while using cutadapt.
 
-``-Z`` (shorthand for ``--compression-level 1``) can be used to limit the
-amount of cpu time which is spent on the compression of output files.
+``-Z`` (shorthand for ``--compression-level=1``) can be used to limit the
+amount of CPU time which is spent on the compression of output files.
 Alternatively, choosing filenames not ending with ``.gz``, ``.bz2`` or ``.xz``
-will make sure no cpu time is spent on compression at all. NOTE: on systems
+will make sure no cpu time is spent on compression at all.  On systems
 with slow I/O, it can actually be faster to set a higher compression-level
 than 1.
 

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -62,6 +62,9 @@ All of Cutadapt's options that expect a file name support this.
 The supported compression formats are gzip (``.gz``), bzip2 (``.bz2``)
 and xz (``.xz``).
 
+The compression level for output gzip (``.gz``) files can be set using
+``--compression-level`` (default=6).
+
 
 Standard input and output
 -------------------------
@@ -153,6 +156,33 @@ Some of these limitations will be lifted in the future, as time allows.
 .. versionadded:: 1.18
     ``--cores=0`` for autodetection
 
+Speed-up tricks
+---------------
+
+There are several tricks for limiting wall-clock time while using cutadapt.
+
+``-Z`` (shorthand for ``--compression-level 1``) can be used to limit the
+amount of cpu time which is spent on the compression of output files.
+Alternatively, choosing filenames not ending with ``.gz``, ``.bz2`` or ``.xz``
+will make sure no cpu time is spent on compression at all. NOTE: on systems
+with slow I/O, it can actually be faster to set a higher compression-level
+than 1.
+
+Increasing the number of cores with ``-j`` will increase the number of reads per
+minute at near-linear rate.
+
+It is also possible to use pipes in order to bypass the filesystem and pipe
+cutadapt's output into an aligner such as BWA. The ``mkfifo`` command allows
+you to create named pipes in bash.
+
+.. code-block::bash
+
+    mkfifo R1.fastq R2.fastq
+    cutadapt -a ${ADAPTER_R1} -A ${ADAPTER_R2} -o R1.fastq -p R2.fastq ${READ1} ${READ2} > cutadapt.report & \
+    bwa mem ${INDEX} <R1.fastq <R2.fastq
+
+This command will run cutadapt and BWA simultaneously, using cutadapts output as
+BWA's input, and capturing cutadapts report in ``cutadapt.report``.
 
 Read processing stages
 ======================

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -285,8 +285,10 @@ def get_argument_parser():
             "depending on input. The summary report is sent to standard output. "
             "Use '{name}' in FILE to demultiplex reads into multiple "
             "files. Default: write to standard output")
-    group.add_argument('--output-compression-level', default=6, dest="compresslevel",
+    group.add_argument('--compression-level', default=6, dest="compresslevel",
         help= 'Compression level if gzipped output files are used.  Default: %(default)s')
+    group.add_argument('-Z', action='store_true', dest='Z',
+        help= 'Short-hand for `--compression_level 1`. ')
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "
             "See the documentation for the file format.")
@@ -755,6 +757,8 @@ def main(cmdlineargs=None, default_outfile=sys.stdout.buffer):
             "--colorspace, -c, -d, --double-encode, -t, --trim-primer, "
             "--strip-f3, --maq, --bwa, --no-zero-cap. "
             "Use Cutadapt 1.18 or earlier to work with colorspace data.")
+
+    compresslevel = 1 if args.Z else args.compresslevel
     paired = determine_paired_mode(args)
     assert paired in (False, True)
 
@@ -765,7 +769,7 @@ def main(cmdlineargs=None, default_outfile=sys.stdout.buffer):
         input_filename, input_paired_filename = input_files_from_parsed_args(args.inputs,
             paired, is_interleaved_input)
         pipeline = pipeline_from_parsed_args(args, paired, is_interleaved_output)
-        outfiles = open_output_files(args, default_outfile, is_interleaved_output, args.compresslevel)
+        outfiles = open_output_files(args, default_outfile, is_interleaved_output, compresslevel)
     except CommandLineError as e:
         parser.error(e)
         return  # avoid IDE warnings below

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -288,7 +288,7 @@ def get_argument_parser():
             "files. Default: write to standard output")
     group.add_argument("--compression-level", default=6,
         help= 'Compression level if gzipped output files are used.  Default: %(default)s')
-    group.add_argument('-Z', action="store_constant", conts=1, dest='compression_level',
+    group.add_argument('-Z', action="store_const", conts=1, dest='compression_level',
         help= 'Short-hand for --compression-level=1.')
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -285,7 +285,7 @@ def get_argument_parser():
             "depending on input. The summary report is sent to standard output. "
             "Use '{name}' in FILE to demultiplex reads into multiple "
             "files. Default: write to standard output")
-    group.add_argument('--output-compression-level', default=1, dest="compresslevel",
+    group.add_argument('--output-compression-level', default=6, dest="compresslevel",
         help= 'Compression level if gzipped output files are used.  Default: %(default)s')
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "
@@ -405,11 +405,11 @@ def open_output_files(args, default_outfile, interleaved, compresslevel):
     """
     rest_file = info_file = wildcard = None
     if args.rest_file is not None:
-        rest_file = xopen(args.rest_file, 'w')
+        rest_file = xopen(args.rest_file, 'w',compresslevel=compresslevel)
     if args.info_file is not None:
-        info_file = xopen(args.info_file, 'w')
+        info_file = xopen(args.info_file, 'w', compresslevel=compresslevel)
     if args.wildcard_file is not None:
-        wildcard = xopen(args.wildcard_file, 'w')
+        wildcard = xopen(args.wildcard_file, 'w', compresslevel=compresslevel)
 
     def open2(path1, path2):
         file1 = file2 = None

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -288,7 +288,7 @@ def get_argument_parser():
             "files. Default: write to standard output")
     group.add_argument("--compression-level", default=6,
         help= 'Compression level if gzipped output files are used.  Default: %(default)s')
-    group.add_argument('-Z', action="store_const", conts=1, dest='compression_level',
+    group.add_argument('-Z', action="store_const", const=1, dest='compression_level',
         help= 'Short-hand for --compression-level=1.')
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -151,6 +151,7 @@ def get_argument_parser():
     group.add_argument("--profile", action="store_true", default=False, help=SUPPRESS)
     group.add_argument('-j', '--cores', type=int, default=1,
         help='Number of CPU cores to use. Use 0 to auto-detect. Default: %(default)s')
+
     # Hidden options
     # GC content as a percentage
     group.add_argument("--gc-content", type=float, default=50,
@@ -285,10 +286,10 @@ def get_argument_parser():
             "depending on input. The summary report is sent to standard output. "
             "Use '{name}' in FILE to demultiplex reads into multiple "
             "files. Default: write to standard output")
-    group.add_argument('--compression-level', default=6, dest="compresslevel",
+    group.add_argument("--compression-level", default=6,
         help= 'Compression level if gzipped output files are used.  Default: %(default)s')
-    group.add_argument('-Z', action='store_true', dest='Z',
-        help= 'Short-hand for `--compression_level 1`. ')
+    group.add_argument('-Z', action="store_constant", conts=1, dest='compression_level',
+        help= 'Short-hand for --compression-level=1.')
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "
             "See the documentation for the file format.")
@@ -758,7 +759,6 @@ def main(cmdlineargs=None, default_outfile=sys.stdout.buffer):
             "--strip-f3, --maq, --bwa, --no-zero-cap. "
             "Use Cutadapt 1.18 or earlier to work with colorspace data.")
 
-    compresslevel = 1 if args.Z else args.compresslevel
     paired = determine_paired_mode(args)
     assert paired in (False, True)
 
@@ -769,7 +769,7 @@ def main(cmdlineargs=None, default_outfile=sys.stdout.buffer):
         input_filename, input_paired_filename = input_files_from_parsed_args(args.inputs,
             paired, is_interleaved_input)
         pipeline = pipeline_from_parsed_args(args, paired, is_interleaved_output)
-        outfiles = open_output_files(args, default_outfile, is_interleaved_output, compresslevel)
+        outfiles = open_output_files(args, default_outfile, is_interleaved_output, args.compression_level)
     except CommandLineError as e:
         parser.error(e)
         return  # avoid IDE warnings below


### PR DESCRIPTION
Current default for compression when using xopen with pigz is 6. Which is a sane default for most use cases. But for fastq reads it is less than ideal. fastq.gz reads after cutting are used for alignment but not saved for long-term storage like raw reads. Therefore speed is much more important than filesize.

This PR adds a command line flag which sets the compression level. (If not set defaults to 6) ~~default to 1 (and allows people who do not agree to set another level).~~

Performance at compression level 6
```
time cutadapt --quiet -a AGATCGGAAGAG -A AGATCGGAAGAG -o cut_R1.fq.gz -p cut_R2.fq.gz U0b_TGACCA_L001_R1_001.fastq.gz U0b_TGACCA_L001_R2_001.fastq.gz 
[=8          ] 00:01:40     4,000,000 reads  @     25.0 µs/read;   2.40 M reads/minute

real	1m40.323s
user	7m52.860s
sys	0m4.764s
```
```
du -h cut_R*.fq.gz 
409M	cut_R1.fq.gz
439M	cut_R2.fq.gz
```

After PR compression at level 1
```
cutadapt --quiet --compression-level 1 -a AGATCGGAAGAG -A AGATCGGAAGAG -o cut_R1.fq.gz -p cut_R2.fq.gz U0b_TGACCA_L001_R1_001.fastq.gz U0b_TGACCA_L001_R2_001.fastq.gz 

[----=8      ] 00:01:23     4,000,000 reads  @     20.8 µs/read;   2.89 M reads/minute

real	1m23.390s
user	2m13.692s
sys	0m5.132s
```
```
du -h cut_R*.fq.gz 
480M	cut_R1.fq.gz
508M	cut_R2.fq.gz
```

An absolutely massive 70% reduction in CPU time is worth the slightly larger file sizes IMHO.

