### PR TITLE
Use newer version of xopen.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     entry_points={'console_scripts': ['cutadapt = cutadapt.__main__:main']},
-    install_requires=['dnaio>=0.3', 'xopen>=0.5.0'],
+    install_requires=['dnaio>=0.3', 'xopen>=0.6.0'],
     extras_require={
         'dev': ['Cython', 'pytest', 'pytest-timeout', 'sphinx', 'sphinx_issues'],
     },


### PR DESCRIPTION
This will run decompression for each input file in a separate thread using a PipedGzipReader  (using `pigz`) this is much faster than trying to read in two gzipped files in the main thread.

As a side note: What are the milestones that need to be reached for cutadapt 2.4? If this is still a while away, with your permission I will update the cutadapt 2.3 bioconda package to xopen>=0.6.0. This will trigger a rebuild of the cutadapt 2.3 biocontainer so that it will be much faster in production.
