### PR TITLE
Add type for compression level

### DIFF
--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -171,7 +171,7 @@ def get_argument_parser():
     group.add_argument("--buffer-size", type=int, default=4000000,
         help=SUPPRESS)
     # Compression level for gzipped output files. Not exposed since we have -Z
-    group.add_argument("--compression-level", default=6,
+    group.add_argument("--compression-level", type=int, default=6,
         help=SUPPRESS)
     # Deprecated: The input format is always auto-detected
     group.add_argument("-f", "--format", help=SUPPRESS)


### PR DESCRIPTION
If this evaluates to string the xopen library will throw errors. Because `"1" in range(1,10) == False`

Since this is hidden there is no haste. I will use `-Z` for now. It is less explicit, but it works fine.
