### PR TITLE
pass threads argument to xopen

### DIFF
--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -387,19 +387,20 @@ def open_output_files(args, default_outfile, interleaved):
     attributes are not opened files, but paths (out and out2 with the '{name}' template).
     """
     compression_level = args.compression_level
+    threads = args.cores
 
     def open1(path):
         """Return opened file (or None if path is None)"""
         if path is None:
             return None
-        return xopen(path, "w", compresslevel=compression_level)
+        return xopen(path, "w", compresslevel=compression_level, threads=threads)
 
     def open2(path1, path2):
         file1 = file2 = None
         if path1 is not None:
-            file1 = xopen(path1, 'wb', compresslevel=compression_level)
+            file1 = xopen(path1, 'wb', compresslevel=compression_level, threads=threads)
             if path2 is not None:
-                file2 = xopen(path2, 'wb', compresslevel=compression_level)
+                file2 = xopen(path2, 'wb', compresslevel=compression_level, threads=threads)
         return file1, file2
 
     rest_file = open1(args.rest_file)


### PR DESCRIPTION
Hi @marcelm here a first suggestion to make cutadapt use xopen's threads argument

- If I get it right cutadapt itself uses `cores` processes it self. Hence I guess that now cutadapt might use up to 2x `cores` processes (50:50 for the pigz threads and cutadapt processes). One might also use different arguments to control this. 