### PR TITLE
defaults for limiting thread usage

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -154,6 +154,38 @@ Some of these limitations will be lifted in the future, as time allows.
 .. versionadded:: 2.5
     Multicore works with ``--untrimmed/too-short/too-long-(paired)-output``
 
+Core usage
+----------
+
+Cutadapt is heavily parallelized in order to take full advantage of the
+available resources. It opens compressed input files in separate threads in
+order to decrease the runtime. It does the same for writing compressed output
+files.
+
+The formula to calculate the number of threads used by cutadapt is
+
+.. code-block:: text
+
+    number_of_input_files +
+    number_of_output_files *
+    <compression threads set by the compression-threads flag (default = 4)> +
+    <cores set by the core flag>`
+
+
+Example: reading two input files which are gzipped and outputting to two
+gzipped output files, while setting cutadapt cores to 4 will use ``2 + 2 * 4 + 4 = 14``
+threads. This does not mean that 14 cores are fully utilized as the decompression
+and compression threads are mostly waiting for cutadapt to finish.
+
+Limiting the number of cores used
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The easiest way to limit the number of cores used by cutadapt is to write to
+uncompressed files. This means output files will not need extra threads for
+compression.
+
+If compressed output files are required the ``-Z`` flag can be used. This will
+default to 1 thread per output file.
 
 Speed-up tricks
 ---------------

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     entry_points={'console_scripts': ['cutadapt = cutadapt.__main__:main']},
     install_requires=[
         'dnaio~=0.4.0',
-        'xopen~=0.8.1',
+        'xopen~=0.8.3',
     ],
     extras_require={
         'dev': ['Cython', 'pytest', 'pytest-timeout', 'sphinx', 'sphinx_issues'],

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -129,10 +129,9 @@ def get_argument_parser():
     # Buffer size for the reader process when running in parallel
     group.add_argument("--buffer-size", type=int, default=4000000,
         help=SUPPRESS)
-    # Compression level for gzipped output files.
-    group.add_argument("--compression-level", type=int, default=1,
-                       help="Compression level for output files. Uses '1' by default for fast "
-                            "speeds.")
+    # Compression level for gzipped output files. Not exposed since we have -Z
+    group.add_argument("--compression-level", type=int, default=6,
+        help=SUPPRESS)
     group.add_argument("--compression-threads", type=int, default=1,
                        help="The number of threads that should be used for compressing the output files. "
                             "Uses '1' by default as using multiple threads will cause cpu overhead.")
@@ -268,8 +267,7 @@ def get_argument_parser():
     group.add_argument("--fasta", default=False, action='store_true',
         help="Output FASTA to standard output even on FASTQ input.")
     group.add_argument("-Z", action="store_const", const=1, dest="compression_level",
-        help=SUPPRESS)  # This is deprecated as it is now the default.
-    # Original message: "Use compression level 1 for gzipped output files (faster, but uses more space)"
+        help="Use compression level 1 for gzipped output files (faster, but uses more space)")
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "
             "See the documentation for the file format.")

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -132,9 +132,9 @@ def get_argument_parser():
     # Compression level for gzipped output files. Not exposed since we have -Z
     group.add_argument("--compression-level", type=int, default=6,
         help=SUPPRESS)
-    group.add_argument("--compression-threads", type=int, default=1,
-                       help="The number of threads that should be used for compressing the output files. "
-                            "Uses '1' by default as using multiple threads will cause cpu overhead.")
+    # The number of threads that should be used for compressing the output files.
+    group.add_argument("--compression-threads", type=int, default=None,
+                       help=SUPPRESS)
     # Deprecated: The input format is always auto-detected
     group.add_argument("-f", "--format", help=SUPPRESS)
 
@@ -390,7 +390,10 @@ def open_output_files(args, default_outfile, interleaved):
     attributes are not opened files, but paths (out and out2 with the '{name}' template).
     """
     compression_level = args.compression_level
-    compression_threads = args.compression_threads
+    # Use user-defined compression threads, or choose a number based on
+    # compression level.
+    compression_threads = args.compression_threads or (
+        1 if compression_level==1 else 4)
 
     def open1(path):
         """Return opened file (or None if path is None)"""

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -268,7 +268,8 @@ def get_argument_parser():
     group.add_argument("--fasta", default=False, action='store_true',
         help="Output FASTA to standard output even on FASTQ input.")
     group.add_argument("-Z", action="store_const", const=1, dest="compression_level",
-        help=SUPPRESS)  # This is deprecated as it is now the default. Original message: "Use compression level 1 for gzipped output files (faster, but uses more space)"
+        help=SUPPRESS)  # This is deprecated as it is now the default.
+    # Original message: "Use compression level 1 for gzipped output files (faster, but uses more space)"
     group.add_argument("--info-file", metavar="FILE",
         help="Write information about each read and its adapter matches into FILE. "
             "See the documentation for the file format.")

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -396,7 +396,7 @@ def open_output_files(args, default_outfile, interleaved):
         """Return opened file (or None if path is None)"""
         if path is None:
             return None
-        return xopen(path, "w", compresslevel=compression_level)
+        return xopen(path, "w", compresslevel=compression_level, threads=compression_threads)
 
     def open2(path1, path2):
         file1 = file2 = None

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -393,7 +393,7 @@ def open_output_files(args, default_outfile, interleaved):
     # Use user-defined compression threads, or choose a number based on
     # compression level.
     compression_threads = args.compression_threads or (
-        1 if compression_level==1 else 4)
+        1 if compression_level == 1 else 4)
 
     def open1(path):
         """Return opened file (or None if path is None)"""

--- a/src/cutadapt/pipeline.py
+++ b/src/cutadapt/pipeline.py
@@ -412,9 +412,10 @@ def reader_process(file, file2, connections, queue, buffer_size, stdin_fd):
         sys.stdin.close()
         sys.stdin = os.fdopen(stdin_fd)
     try:
-        with xopen(file, 'rb') as f:
+        # use 1 decompression thread by default. This reduces a lot of cpu overhead in pigz.
+        with xopen(file, 'rb', threads=1) as f:
             if file2:
-                with xopen(file2, 'rb') as f2:
+                with xopen(file2, 'rb', threads=1) as f2:
                     for chunk_index, (chunk1, chunk2) in enumerate(dnaio.read_paired_chunks(f, f2, buffer_size)):
                         send_to_worker(chunk_index, chunk1, chunk2)
             else:


### PR DESCRIPTION
Using a low compression level and a default thread count of 1 for all operations will drastically reduce the amount of cpu resources by cutadapt.

Hopefully solves https://github.com/bioconda/bioconda-recipes/pull/18158