### PR TITLE
fix when combining non-default actions and paired adapters

### DIFF
--- a/src/cutadapt/modifiers.py
+++ b/src/cutadapt/modifiers.py
@@ -317,9 +317,9 @@ class PairedAdapterCutter(PairedModifier):
                 # read is already trimmed, nothing to do
                 pass
             elif self.action == 'mask':
-                trimmed_read = AdapterCutter.masked_read(trimmed_read, [match])
+                trimmed_read = AdapterCutter.masked_read(read, trimmed_read, [match])
             elif self.action == 'lowercase':
-                trimmed_read = AdapterCutter.lowercased_read(trimmed_read, [match])
+                trimmed_read = AdapterCutter.lowercased_read(read, trimmed_read, [match])
                 assert len(trimmed_read.sequence) == len(read)
             elif self.action is None:  # --no-trim
                 trimmed_read = read[:]


### PR DESCRIPTION
Using both --action=lowercase and --pair-adapters resulted in a TypeError. The cause was a missing required positional argument. Upon investigation, the same missing argument was found for masked reads. This fixes both.