### PR TITLE
Use file opener with 1 thread by default.

### DIFF
--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -835,7 +835,7 @@ def main(cmdlineargs=None, default_outfile=sys.stdout.buffer):
 
     cores = available_cpu_count() if args.cores == 0 else args.cores
     file_opener = FileOpener(
-        compression_level=args.compression_level, threads=0 if cores == 1 else None)
+        compression_level=args.compression_level, threads=0 if cores == 1 else 1)
     if sys.stderr.isatty() and not args.quiet:
         progress = Progress()
     else:


### PR DESCRIPTION
Many compression programs do support multithreaded compression. However this comes with a performance overhead. Since cutadapt usually opens 4 files (r1 and r2 in && r1 and r2 out) it is most probable the cutadapt will be the bottleneck, not any of the threads writing the output files.

Using more than one thread per file only makes sense in two cases:
- Compression level is set too high.
- Cutadapt outputs so much that even with a low compression level the output file threads cannot keep up. 

Current behaviour is that having cutadapt threads >1 this will spawn two pigz decompression threads on 1 thread and two pigz compression threads on 4 threads for a total of 10 extra threads.
After this change only 4 extra threads will be used.