### PR TITLE
Fix for sometimes too short sequence trimmed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ development version
 -------------------
 
 * :issue:`469`: Cutadapt did not run under Python 3.8 on recent macOS versions.
+* :pr:`485`: Fix that, under some circumstances, in particular when trimming a
+  5' adapter and there was a mismatch in its last nucleotide(s), not the entire adapter
+  sequence would be trimmed from the read. Since fixing this required changed the
+  alignment algorithm slightly, this is a backwards incompatible change.
 
 v2.10 (2020-04-22)
 ------------------

--- a/src/cutadapt/_align.pyx
+++ b/src/cutadapt/_align.pyx
@@ -511,7 +511,9 @@ cdef class Aligner:
                     cost = column[m].cost
                     matches = column[m].matches
                     if length >= self._min_overlap and cost <= cur_effective_length * max_error_rate and (matches > best.matches or (matches == best.matches and cost < best.cost)):
-                        # update
+                        # The case "matches == best.matches and cost < best.cost" applies
+                        # when the query contains the reference twice, and where the right
+                        # occurrence contains fewer errors
                         best.matches = matches
                         best.cost = cost
                         best.origin = column[m].origin

--- a/src/cutadapt/_align.pyx
+++ b/src/cutadapt/_align.pyx
@@ -522,7 +522,14 @@ cdef class Aligner:
                         length >= self._min_overlap
                         and cost <= cur_effective_length * max_error_rate
                     )
-                    if is_acceptable and (score > best.score or (matches == best.matches and cost < best.cost)):
+                    if is_acceptable and (
+                        # no best match recorded so far
+                        (best.cost == m + n)
+                        # same start position, use score to judge whether this is better
+                        or (origin == best.origin and score > best.score)
+                        # different start position, only matches count
+                        or (matches > best.matches or (matches == best.matches and cost < best.cost))
+                    ):
                         # The case "matches == best.matches and cost < best.cost" applies
                         # when the query contains the reference twice, and where the right
                         # occurrence contains fewer errors
@@ -563,7 +570,14 @@ cdef class Aligner:
                     length >= self._min_overlap
                     and cost <= cur_effective_length * max_error_rate
                 )
-                if is_acceptable and (score > best.score or (matches == best.matches and cost < best.cost)):
+                if is_acceptable and (
+                    # no best match recorded so far
+                    (best.cost == m + n)
+                    # same start position, use score to judge whether this is better
+                    or (origin == best.origin and score > best.score)
+                    # different start position, only matches count
+                    or (matches > best.matches or (matches == best.matches and cost < best.cost))
+                ):
                     best.matches = matches
                     best.score = score
                     best.cost = cost

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -85,7 +85,6 @@ def test_back_adapter_indel_and_exact_occurrence():
     assert match.rstop == 10
 
 
-@pytest.mark.xfail(strict=True)
 def test_back_adapter_indel_and_mismatch_occurrence():
     adapter = BackAdapter(
         sequence="GATCGGAAGA",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -85,6 +85,24 @@ def test_back_adapter_indel_and_exact_occurrence():
     assert match.rstop == 10
 
 
+def test_back_adapter_indel_and_mismatch_occurrence():
+    adapter = BackAdapter(
+        sequence="GATCGGAAGA",
+        max_error_rate=0.1,
+        min_overlap=3,
+    )
+    match = adapter.match_to("CTGGATCGGAGAGCCGTAGATCGGGAGAGGC")
+    # CTGGATCGGA-GAGCCGTAGATCGGGAGAGGC
+    #    ||||||| ||      ||||||X|||
+    #    GATCGGAAGA      GATCGGAAGA
+    assert match.errors == 1
+    assert match.matches == 9
+    assert match.astart == 0
+    assert match.astop == 10
+    assert match.rstart == 3
+    assert match.rstop == 12
+
+
 def test_str():
     a = BackAdapter('ACGT', max_error_rate=0.1)
     str(a)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -85,6 +85,7 @@ def test_back_adapter_indel_and_exact_occurrence():
     assert match.rstop == 10
 
 
+@pytest.mark.xfail(strict=True)
 def test_back_adapter_indel_and_mismatch_occurrence():
     adapter = BackAdapter(
         sequence="GATCGGAAGA",
@@ -107,6 +108,42 @@ def test_str():
     a = BackAdapter('ACGT', max_error_rate=0.1)
     str(a)
     str(a.match_to("TTACGT"))
+
+
+def test_prefix_with_indels_one_mismatch():
+    a = PrefixAdapter(
+        sequence="GCACATCT",
+        max_error_rate=0.15,
+        min_overlap=1,
+        read_wildcards=False,
+        adapter_wildcards=False,
+        indels=True,
+    )
+    result = a.match_to("GCACATCGGAA")
+    assert result.errors == 1
+    assert result.matches == 7
+    assert result.astart == 0
+    assert result.astop == 8
+    assert result.rstart == 0
+    assert result.rstop == 8
+
+
+def test_prefix_with_indels_two_mismatches():
+    a = PrefixAdapter(
+        sequence="GCACATTT",
+        max_error_rate=0.3,
+        min_overlap=1,
+        read_wildcards=False,
+        adapter_wildcards=False,
+        indels=True,
+    )
+    result = a.match_to("GCACATCGGAA")
+    assert result.errors == 2
+    assert result.matches == 6
+    assert result.astart == 0
+    assert result.astop == 8
+    assert result.rstart == 0
+    assert result.rstop == 8
 
 
 def test_linked_adapter():

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -65,6 +65,26 @@ def test_issue_80():
     assert result.astop == 15, result
 
 
+@pytest.mark.xfail(strict=True)
+def test_back_adapter_indel_and_exact_occurrence():
+    adapter = BackAdapter(
+        sequence="GATCGGAAGA",
+        max_error_rate=0.1,
+        min_overlap=3,
+    )
+    match = adapter.match_to("GATCGTGAAGAGATCGGAAGA")
+    # We want the leftmost match of these two possible ones:
+    # GATCGTGAAGAGATCGGAAGA
+    # GATCG-GAAGA
+    #            GATCGGAAGA
+    assert match.errors == 0
+    assert match.matches == 10
+    assert match.astart == 0
+    assert match.astop == 10
+    assert match.rstart == 0
+    assert match.rstop == 10
+
+
 def test_str():
     a = BackAdapter('ACGT', max_error_rate=0.1)
     str(a)


### PR DESCRIPTION
When a read contains a 5' adapter with a mismatch in the last nucleotide(s), the current alignment algorithm prefers to report these as deletions, resulting in the mismatched nucleotides not being trimmed from the read.

An example for how an alignment currently looks like (1 error allowed, 5' adapter):
```
adapter:  GCACATCT
read:     GCACATC- GGAA
```
With this, the read would be trimmed to `GGAA`, but that doesn’t make sense because this seems more likely:
```
adapter:  GCACATCT
read:     GCACATCG GAA
```
With this, the read would be trimmed to `GAA`.

The above example works with both anchored and regular 5' adapters, and something similar happens when *n* errors are allowed and the last *n* nucleotides are mismatches.

The reason for this is that both alignments have the same number of matches, the same costs (number of edits), and that the undesired version is encountered first and then kept.

(One workaround is to use `--no-indels`, which is probably a good thing in many cases anyway.)

To reproduce, run
```
echo -e ">read\nGCACATCGGAA\n" | cutadapt -g ^GCACATCT -e 0.15 -
```
to get a result of
```
>read
GGAA
```

This is the DP matrix that is output with `--debug=trace`:
```
      G  C  A  C  A  T  C  G  G  A  A  T  T  T  A  A
   0  1  2  3  4  5  6  7  8  9
G  1  0  1  2  3  4  5  6  7  8
C  2  1  0  1  2  3  4  5  6  7
A  3     1  0  1  2  3  4  5  6
C  4        1  0  1  2  3  4  5
A  5           1  0  1  2  3  4
T  6              1  0  1  2  3
C  7                 1  0  1  2
T  8                    1  1  2
```
The numbers are the edit distances. There are two cells in the last row with the value 1, which correspond to the two alignment possibilities listed above. The left "1" corresponds to the undesired alignment with an indel, which is found first.

The fix in this PR changes the way in which the best alignment is found: If there are multiple possible alignment end positions leading to alignments with the same number of matches, the end position with the fewest indels is chosen.