### PR TITLE
Lift the restriction that an index is created only with --no-indels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ development version
 * :issue:`358`: You can now use ``-e`` also :ref:`to specify the maximum number of
   errors <error-tolerance>` (instead of the maximum error rate). For example, write
   ``-e 2`` to allow two errors over a full-length adapter match.
+* :pr:`486`: Trimming many anchored adapters (for example when demultiplexing)
+  is now faster by using an index even when indels are allowed. Previously, Cutadapt
+  would only be able to build an index with ``--no-indels``.
 * :issue:`469`: Cutadapt did not run under Python 3.8 on recent macOS versions.
 * :pr:`485`: Fix that, under some circumstances, in particular when trimming a
   5' adapter and there was a mismatch in its last nucleotide(s), not the entire adapter

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -1663,9 +1663,8 @@ following conditions need to be met in order for index creation to be enabled:
 * The barcodes/adapters must be anchored 5’ adapters (``-g ^ADAPTER``) or anchored 3’ adapters
   (``-a ADAPTER$``). If you use ``file:`` to read in the adapter sequences from a FASTA file,
   remember to add the ``^`` or ``$`` to each sequence in the FASTA file.
-* The maximum error rate (``-e``) must be set in such a way as to allow at most 2 errors or less.
-  For example, if the barcode has length 10, you can use ``-e 0.2`` (or lower).
-* The option ``--no-indels`` must be used.
+* The maximum error rate (``-e``) must be set such that at most 2 errors are allowed,
+  so use ``-e 0``, ``-e 1`` or ``-e 2``.
 * No IUPAC wildcards must be used in the barcode/adapter. Also, you cannot use the option
   ``--match-read-wildcards``.
 
@@ -1685,6 +1684,10 @@ Hopefully some of the above restrictions will be lifted in the future.
 
 .. versionadded:: 2.0
    Added ability to use an index of adapters for speeding up demultiplexing
+
+.. versionadded::
+   An index can be built even when indels are allowed (that is, ``--no-indels``
+   is no longer required).
 
 
 Demultiplexing paired-end reads in mixed orientation

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -143,6 +143,8 @@ def get_argument_parser() -> ArgumentParser:
         help=SUPPRESS)
     # Deprecated: The input format is always auto-detected
     group.add_argument("-f", "--format", help=SUPPRESS)
+    # Disable adapter index creation
+    group.add_argument("--no-index", dest="index", default=True, action="store_false", help=SUPPRESS)
 
     group = parser.add_argument_group("Finding adapters",
         description="Parameters -a, -g, -b specify adapters to be removed from "
@@ -653,6 +655,7 @@ def pipeline_from_parsed_args(args, paired, file_opener) -> Pipeline:
         args.action,
         args.times,
         args.reverse_complement,
+        args.index,
     )
 
     for modifier in modifiers_applying_to_both_ends_if_paired(args):
@@ -733,6 +736,7 @@ def add_adapter_cutter(
     action: str,
     times: int,
     reverse_complement: bool,
+    allow_index: bool,
 ):
     if pair_adapters:
         if reverse_complement:
@@ -745,9 +749,9 @@ def add_adapter_cutter(
     else:
         adapter_cutter, adapter_cutter2 = None, None
         if adapters:
-            adapter_cutter = AdapterCutter(adapters, times, action)
+            adapter_cutter = AdapterCutter(adapters, times, action, allow_index)
         if adapters2:
-            adapter_cutter2 = AdapterCutter(adapters2, times, action)
+            adapter_cutter2 = AdapterCutter(adapters2, times, action, allow_index)
         if paired:
             if reverse_complement:
                 raise CommandLineError("--revcomp not implemented for paired-end reads")

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -451,7 +451,7 @@ class SingleAdapter(Adapter, ABC):
     def __len__(self):
         return len(self.sequence)
 
-    def create_statistics(self):
+    def create_statistics(self) -> AdapterStatistics:
         return AdapterStatistics(self, self)
 
 
@@ -732,7 +732,7 @@ class LinkedAdapter(Adapter):
             return None
         return LinkedMatch(front_match, back_match, self)
 
-    def create_statistics(self):
+    def create_statistics(self) -> AdapterStatistics:
         return AdapterStatistics(self, self.front_adapter, self.back_adapter)
 
     @property

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -530,7 +530,7 @@ class AnywhereAdapter(SingleAdapter):
         return None if no match was found given the matching criteria (minimum
         overlap length, maximum error rate).
         """
-        alignment = self.aligner.locate(sequence)
+        alignment = self.aligner.locate(sequence.upper())
         if self._debug:
             print(self.aligner.dpmatrix)  # pragma: no cover
         if alignment is None:
@@ -552,6 +552,7 @@ class NonInternalFrontAdapter(FrontAdapter):
         return self._make_aligner(Where.FRONT_NOT_INTERNAL.value)
 
     def match_to(self, sequence: str):
+        # The locate function takes care of uppercasing the sequence
         alignment = self.aligner.locate(sequence)
         if self._debug:
             try:
@@ -572,6 +573,7 @@ class NonInternalBackAdapter(BackAdapter):
         return self._make_aligner(Where.BACK_NOT_INTERNAL.value)
 
     def match_to(self, sequence: str):
+        # The locate function takes care of uppercasing the sequence
         alignment = self.aligner.locate(sequence)
         if self._debug:
             try:
@@ -751,7 +753,6 @@ class MultiAdapter(Adapter, ABC):
     method, but is faster with lots of adapters.
 
     There are quite a few restrictions:
-    - no indels are allowed
     - the error rate allows at most 2 mismatches
     - wildcards in the adapter are not allowed
     - wildcards in the read are not allowed
@@ -790,8 +791,6 @@ class MultiAdapter(Adapter, ABC):
         if adapter.adapter_wildcards:
             raise ValueError("Wildcards in the adapter not supported")
         k = int(len(adapter) * adapter.max_error_rate)
-        if k > 0 and adapter.indels:
-            raise ValueError("Indels not allowed")
         if k > 2:
             raise ValueError("Error rate too high")
 
@@ -817,7 +816,8 @@ class MultiAdapter(Adapter, ABC):
         for adapter in self._adapters:
             sequence = adapter.sequence
             k = int(adapter.max_error_rate * len(sequence))
-            for s, errors, matches in align.hamming_environment(sequence, k):
+            environment = align.edit_environment if adapter.indels else align.hamming_environment
+            for s, errors, matches in environment(sequence, k):
                 if s in index:
                     other_adapter, other_errors, other_matches = index[s]
                     if matches < other_matches:
@@ -843,6 +843,8 @@ class MultiAdapter(Adapter, ABC):
         Match the adapters against a string and return a Match that represents
         the best match or None if no match was found
         """
+        original_sequence = sequence
+        sequence = sequence.upper()
         # Check all the prefixes or suffixes (affixes) that could match
         best_adapter = None  # type: Optional[SingleAdapter]
         best_length = 0
@@ -868,7 +870,7 @@ class MultiAdapter(Adapter, ABC):
             return None
         else:
             assert best_adapter is not None
-            return self._make_match(best_adapter, best_length, best_m, best_e, sequence)
+            return self._make_match(best_adapter, best_length, best_m, best_e, original_sequence)
 
     def enable_debug(self):
         pass

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -746,7 +746,7 @@ class LinkedAdapter(Adapter):
         return None
 
 
-class MultiAdapter(Adapter, ABC):
+class IndexedAdapters(Adapter, ABC):
     """
     Represent multiple adapters of the same type at once and use an index data structure
     to speed up matching. This acts like a "normal" Adapter as it provides a match_to
@@ -759,11 +759,11 @@ class MultiAdapter(Adapter, ABC):
 
     Use the is_acceptable() method to check individual adapters.
     """
-    MultiAdapterIndex = Dict[str, Tuple[SingleAdapter, int, int]]
+    AdapterIndex = Dict[str, Tuple[SingleAdapter, int, int]]
 
     def __init__(self, adapters):
         """All given adapters must be of the same type"""
-        super().__init__(name="multi_adapter")
+        super().__init__(name="indexed_adapters")
         if not adapters:
             raise ValueError("Adapter list is empty")
         for adapter in adapters:
@@ -806,7 +806,7 @@ class MultiAdapter(Adapter, ABC):
     @classmethod
     def is_acceptable(cls, adapter):
         """
-        Return whether this adapter is acceptable for being used by MultiAdapter
+        Return whether this adapter is acceptable for being used in an index
 
         Adapters are not acceptable if they allow wildcards, allow too many errors,
         or would lead to a very large index.
@@ -817,9 +817,9 @@ class MultiAdapter(Adapter, ABC):
             return False
         return True
 
-    def _make_index(self) -> Tuple[List[int], "MultiAdapterIndex"]:
+    def _make_index(self) -> Tuple[List[int], "AdapterIndex"]:
         logger.info('Building index of %s adapters ...', len(self._adapters))
-        index = dict()  # type: MultiAdapter.MultiAdapterIndex
+        index = dict()  # type: IndexedAdapters.AdapterIndex
         lengths = set()
         has_warned = False
         for adapter in self._adapters:
@@ -911,7 +911,7 @@ class MultiAdapter(Adapter, ABC):
         pass
 
 
-class MultiPrefixAdapter(MultiAdapter):
+class IndexedPrefixAdapters(IndexedAdapters):
 
     @classmethod
     def _accept(cls, adapter):
@@ -939,7 +939,7 @@ class MultiPrefixAdapter(MultiAdapter):
         return s[:n]
 
 
-class MultiSuffixAdapter(MultiAdapter):
+class IndexedSuffixAdapters(IndexedAdapters):
 
     @classmethod
     def _accept(cls, adapter):

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -746,6 +746,44 @@ class LinkedAdapter(Adapter):
         return None
 
 
+class MultipleAdapters(Adapter):
+    """
+    Represent multiple adapters at once
+    """
+    def __init__(self, adapters: Sequence[Adapter]):
+        super().__init__(name="multiple_adapters")
+        self._adapters = adapters
+
+    def enable_debug(self):
+        for a in self._adapters:
+            a.enable_debug()
+
+    def __getitem__(self, item):
+        return self._adapters[item]
+
+    def __len__(self):
+        return len(self._adapters)
+
+    def match_to(self, sequence: str) -> Optional[SingleMatch]:
+        """
+        Find the adapter that best matches the sequence.
+
+        Return either a Match instance or None if there are no matches.
+        """
+        best_match = None
+        for adapter in self._adapters:
+            match = adapter.match_to(sequence)
+            if match is None:
+                continue
+
+            # the no. of matches determines which adapter fits best
+            if best_match is None or match.matches > best_match.matches or (
+                match.matches == best_match.matches and match.errors < best_match.errors
+            ):
+                best_match = match
+        return best_match
+
+
 class IndexedAdapters(Adapter, ABC):
     """
     Represent multiple adapters of the same type at once and use an index data structure

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -852,11 +852,17 @@ class MultiAdapter(Adapter, ABC):
         Match the adapters against a string and return a Match that represents
         the best match or None if no match was found
         """
+        affix = self._make_affix(sequence.upper(), self._length)
+        if "N" in affix:
+            affix = affix.replace("N", "A")
+            n_count = affix.count("N")
+        else:
+            n_count = 0
         try:
-            adapter, e, m = self._index[self._make_affix(sequence.upper(), self._length)]
+            adapter, e, m = self._index[affix]
         except KeyError:
             return None
-        return self._make_match(adapter, self._length, m, e, sequence)
+        return self._make_match(adapter, self._length, m - n_count, e + n_count, sequence)
 
     def _match_to_multiple_lengths(self, sequence: str):
         """

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -772,7 +772,7 @@ class MultiAdapter(Adapter, ABC):
         self._make_affix = self._get_make_affix()
 
     def __repr__(self):
-        return "MultiAdapter(adapters={!r})".format(self._adapters)
+        return "{}(adapters={!r})".format(self.__class__.__name__, self._adapters)
 
     @abstractmethod
     def _get_make_affix(self):

--- a/src/cutadapt/align.py
+++ b/src/cutadapt/align.py
@@ -4,6 +4,8 @@ __all__ = [
     'SuffixComparer',
     'hamming_sphere',
     'hamming_environment',
+    'edit_environment',
+    'edit_distance',
 ]
 
 from cutadapt._align import Aligner, PrefixComparer, SuffixComparer
@@ -24,6 +26,32 @@ STOP_WITHIN_SEQ2 = 8
 # Use this to get regular semiglobal alignment
 # (all gaps in the beginning or end are free)
 SEMIGLOBAL = START_WITHIN_SEQ1 | START_WITHIN_SEQ2 | STOP_WITHIN_SEQ1 | STOP_WITHIN_SEQ2
+
+
+def edit_distance(s: str, t: str):
+    """
+    Return the edit distance between the strings s and t.
+    The edit distance is the sum of the numbers of insertions, deletions,
+    and mismatches that is minimally necessary to transform one string
+    into the other.
+    """
+    m = len(s)  # index i
+    n = len(t)  # index j
+    costs = list(range(m + 1))
+
+    for j in range(1, n + 1):
+        prev = costs[0]
+        costs[0] += 1
+        for i in range(1, m + 1):
+            match = int(s[i - 1] == t[j - 1])
+            c = min(
+                prev + 1 - match,
+                costs[i] + 1,
+                costs[i - 1] + 1,
+            )
+            prev = costs[i]
+            costs[i] = c
+    return costs[-1]
 
 
 def hamming_sphere(s, k):
@@ -63,3 +91,93 @@ def hamming_environment(s, k):
     for e in range(k + 1):
         for t in hamming_sphere(s, e):
             yield t, e, n - e
+
+
+def naive_edit_environment(s: str, k: int):
+    """
+    Apply all possible edits up to edit distance k to string s.
+    A string may be returned more than once.
+    """
+    yield s
+    if k == 0:
+        return
+    for s in naive_edit_environment(s, k - 1):
+        n = len(s)
+        for ch in 'ACGT':
+            # all insertions
+            for i in range(n+1):
+                x = s[:i] + ch + s[i:]
+                assert len(x) == len(s) + 1
+                yield x
+            # all substitutions
+            for i in range(n):
+                x = s[:i] + ch + s[i+1:]
+                assert len(x) == len(s)
+                yield x
+        # all deletions
+        for i in range(n):
+            x = s[:i] + s[i+1:]
+            assert len(x) == len(s) - 1
+            yield x
+
+
+def edit_environment(s: str, k: int):
+    """
+    Find all strings t for which the edit distance between s and t is at most k,
+    assuming the alphabet is A, C, G, T.
+
+    Yield tuples (t, e, m), where e is the edit distance between s and t and
+    m is the number of matches in the optimal alignment.
+    """
+    n = len(s)
+    alphabet = "TGCA"
+    work_stack = [(
+        "",
+        list(range(n + 1)),
+        [0] * (n + 1),
+    )]
+    while work_stack:
+        # t is the current prefix
+        # costs is a row at index len(t) in the DP matrix
+        # matches is a row in the corresponding matrix of the no. of matches
+        t, costs, matches = work_stack.pop()
+
+        # The row is the last row of the DP matrix for aligning t against s
+        i = len(t)
+        if costs[-1] <= k:
+            # The costs of an optimal alignment of t against s are at most k,
+            # so t is within the edit environment.
+            yield t, costs[-1], matches[-1]
+
+        if i == n + k:
+            # Last row reached
+            continue
+
+        # Runtime heuristic: The entries in the DP matrix cannot get lower
+        # in subsequent rows, so don’t try longer suffixs if all entries are
+        # greater than k.
+        if min(costs) > k:
+            continue
+
+        # compute next row in DP matrix for all characters of the alphabet
+        for ch in alphabet:
+            # create a new DP matrix row for each character of the alphabet
+            next_costs = [0] * (n + 1)
+            next_costs[0] = len(t) + 1
+            next_matches = [0] * (n + 1)
+            for j in range(1, n + 1):
+                match = 0 if s[j - 1] == ch else 1
+                assert j > 0
+
+                diag = costs[j-1] + match
+                left = next_costs[j-1] + 1
+                up = costs[j] + 1
+                if diag <= left and diag <= up:
+                    c, m = diag, matches[j-1] + (1 - match)
+                elif left <= up:
+                    c, m = left, next_matches[j-1]
+                else:
+                    c, m = up, matches[j]
+                next_costs[j] = c
+                next_matches[j] = m
+            work_stack.append((t + ch, next_costs, next_matches))

--- a/src/cutadapt/modifiers.py
+++ b/src/cutadapt/modifiers.py
@@ -78,9 +78,7 @@ class AdapterCutter(SingleEndModifier):
         index: bool = True,
     ):
         """
-        adapters -- list of Adapter objects
-
-        action -- What to do with a found adapter: None, 'trim', or 'mask'
+        action -- What to do with a found adapter: None, 'trim', 'mask' or 'lowercase'
 
         index -- if True, an adapter index (for multiple adapters) is created if possible
         """
@@ -140,7 +138,7 @@ class AdapterCutter(SingleEndModifier):
         return prefix, suffix, other
 
     @staticmethod
-    def best_match(adapters, read):
+    def best_match(adapters, sequence):
         """
         Find the best matching adapter in the given read.
 
@@ -148,7 +146,7 @@ class AdapterCutter(SingleEndModifier):
         """
         best_match = None
         for adapter in adapters:
-            match = adapter.match_to(read.sequence)
+            match = adapter.match_to(sequence)
             if match is None:
                 continue
 
@@ -206,7 +204,7 @@ class AdapterCutter(SingleEndModifier):
             read.sequence = read.sequence.upper()
         trimmed_read = read
         for _ in range(self.times):
-            match = AdapterCutter.best_match(self.adapters, trimmed_read)
+            match = AdapterCutter.best_match(self.adapters, trimmed_read.sequence)
             if match is None:
                 # if nothing found, attempt no further rounds
                 break
@@ -312,7 +310,7 @@ class PairedAdapterCutter(PairedModifier):
     def __call__(self, read1, read2, info1, info2):
         """
         """
-        match1 = AdapterCutter.best_match(self._adapters1, read1)
+        match1 = AdapterCutter.best_match(self._adapters1, read1.sequence)
         if match1 is None:
             return read1, read2
         adapter1 = match1.adapter

--- a/src/cutadapt/modifiers.py
+++ b/src/cutadapt/modifiers.py
@@ -70,18 +70,29 @@ class AdapterCutter(SingleEndModifier):
     times parameter.
     """
 
-    def __init__(self, adapters, times=1, action='trim'):
+    def __init__(
+        self,
+        adapters: List[SingleAdapter],
+        times: int = 1,
+        action: str = "trim",
+        index: bool = True,
+    ):
         """
         adapters -- list of Adapter objects
 
         action -- What to do with a found adapter: None, 'trim', or 'mask'
+
+        index -- if True, an adapter index (for multiple adapters) is created if possible
         """
         self.times = times
         assert action in ('trim', 'mask', 'lowercase', None)
         self.action = action
         self.with_adapters = 0
         self.adapter_statistics = OrderedDict((a, a.create_statistics()) for a in adapters)
-        self.adapters = self._regroup_into_indexed_adapters(adapters)
+        if index:
+            self.adapters = self._regroup_into_indexed_adapters(adapters)
+        else:
+            self.adapters = adapters
 
     def __repr__(self):
         return 'AdapterCutter(adapters={!r}, times={}, action={!r})'.format(

--- a/src/cutadapt/modifiers.py
+++ b/src/cutadapt/modifiers.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 
 from .qualtrim import quality_trim_index, nextseq_trim_index
-from .adapters import SingleAdapter, MultiPrefixAdapter, MultiSuffixAdapter, Match, remainder
+from .adapters import SingleAdapter, IndexedPrefixAdapters, IndexedSuffixAdapters, Match, remainder
 from .utils import reverse_complemented_sequence
 
 
@@ -103,11 +103,11 @@ class AdapterCutter(SingleEndModifier):
         if len(prefix) > 1 or len(suffix) > 1:
             result = single
             if len(prefix) > 1:
-                result.append(MultiPrefixAdapter(prefix))
+                result.append(IndexedPrefixAdapters(prefix))
             else:
                 result.extend(prefix)
             if len(suffix) > 1:
-                result.append(MultiSuffixAdapter(suffix))
+                result.append(IndexedSuffixAdapters(suffix))
             else:
                 result.extend(suffix)
             return result
@@ -129,9 +129,9 @@ class AdapterCutter(SingleEndModifier):
         suffix = []  # type: List[SingleAdapter]
         other = []  # type: List[SingleAdapter]
         for a in adapters:
-            if MultiPrefixAdapter.is_acceptable(a):
+            if IndexedPrefixAdapters.is_acceptable(a):
                 prefix.append(a)
-            elif MultiSuffixAdapter.is_acceptable(a):
+            elif IndexedSuffixAdapters.is_acceptable(a):
                 suffix.append(a)
             else:
                 other.append(a)

--- a/src/cutadapt/modifiers.py
+++ b/src/cutadapt/modifiers.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 
 from .qualtrim import quality_trim_index, nextseq_trim_index
-from .adapters import SingleAdapter, IndexedPrefixAdapters, IndexedSuffixAdapters, Match, remainder
+from .adapters import MultipleAdapters, SingleAdapter, IndexedPrefixAdapters, IndexedSuffixAdapters, Match, remainder
 from .utils import reverse_complemented_sequence
 
 
@@ -88,9 +88,9 @@ class AdapterCutter(SingleEndModifier):
         self.with_adapters = 0
         self.adapter_statistics = OrderedDict((a, a.create_statistics()) for a in adapters)
         if index:
-            self.adapters = self._regroup_into_indexed_adapters(adapters)
+            self.adapters = MultipleAdapters(self._regroup_into_indexed_adapters(adapters))
         else:
-            self.adapters = adapters
+            self.adapters = MultipleAdapters(adapters)
 
     def __repr__(self):
         return 'AdapterCutter(adapters={!r}, times={}, action={!r})'.format(
@@ -136,26 +136,6 @@ class AdapterCutter(SingleEndModifier):
             else:
                 other.append(a)
         return prefix, suffix, other
-
-    @staticmethod
-    def best_match(adapters, sequence):
-        """
-        Find the best matching adapter in the given read.
-
-        Return either a Match instance or None if there are no matches.
-        """
-        best_match = None
-        for adapter in adapters:
-            match = adapter.match_to(sequence)
-            if match is None:
-                continue
-
-            # the no. of matches determines which adapter fits best
-            if best_match is None or match.matches > best_match.matches or (
-                match.matches == best_match.matches and match.errors < best_match.errors
-            ):
-                best_match = match
-        return best_match
 
     @staticmethod
     def masked_read(read, matches: Sequence[Match]):
@@ -204,7 +184,7 @@ class AdapterCutter(SingleEndModifier):
             read.sequence = read.sequence.upper()
         trimmed_read = read
         for _ in range(self.times):
-            match = AdapterCutter.best_match(self.adapters, trimmed_read.sequence)
+            match = self.adapters.match_to(trimmed_read.sequence)
             if match is None:
                 # if nothing found, attempt no further rounds
                 break
@@ -294,9 +274,9 @@ class PairedAdapterCutter(PairedModifier):
                 "Given: {} for R1, {} for R2".format(len(adapters1), len(adapters2)))
         if not adapters1:
             raise PairedAdapterCutterError("No adapters given")
-        self._adapters1 = adapters1
+        self._adapters1 = MultipleAdapters(adapters1)
         self._adapter_indices = {a: i for i, a in enumerate(adapters1)}
-        self._adapters2 = adapters2
+        self._adapters2 = MultipleAdapters(adapters2)
         self.action = action
         self.with_adapters = 0
         self.adapter_statistics = [None, None]
@@ -310,7 +290,7 @@ class PairedAdapterCutter(PairedModifier):
     def __call__(self, read1, read2, info1, info2):
         """
         """
-        match1 = AdapterCutter.best_match(self._adapters1, read1.sequence)
+        match1 = self._adapters1.match_to(read1.sequence)
         if match1 is None:
             return read1, read2
         adapter1 = match1.adapter

--- a/src/cutadapt/pipeline.py
+++ b/src/cutadapt/pipeline.py
@@ -264,12 +264,17 @@ class SingleEndPipeline(Pipeline):
         """Run the pipeline. Return statistics"""
         n = 0  # no. of processed reads
         total_bp = 0
+        info = ModificationInfo(None)
         for read in self._reader:
             n += 1
             if n % 10000 == 0 and progress:
                 progress.update(n)
             total_bp += len(read)
-            info = ModificationInfo(read)
+            # To avoid creating new ModificationInfo instances,
+            # which is quite slow, update the ones we already
+            # have in place.
+            info.matches = []
+            info.original_read = read
             for modifier in self._modifiers:
                 read = modifier(read, info)
             for filter_ in self._filters:
@@ -361,14 +366,21 @@ class PairedEndPipeline(Pipeline):
         total1_bp = 0
         total2_bp = 0
         assert self._reader is not None
+        info1 = ModificationInfo(None)
+        info2 = ModificationInfo(None)
         for read1, read2 in self._reader:
             n += 1
             if n % 10000 == 0 and progress:
                 progress.update(n)
             total1_bp += len(read1)
             total2_bp += len(read2)
-            info1 = ModificationInfo(read1)
-            info2 = ModificationInfo(read2)
+            # To avoid creating new ModificationInfo instances,
+            # which is quite slow, update the ones we already
+            # have in place.
+            info1.matches = []
+            info2.matches = []
+            info1.original_read = read1
+            info2.original_read = read2
             for modifier in self._modifiers:
                 read1, read2 = modifier(read1, read2, info1, info2)
             for filter_ in self._filters:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -9,6 +9,7 @@ from cutadapt.adapters import (
     PrefixAdapter,
     SuffixAdapter,
     LinkedAdapter,
+    MultipleAdapters,
     IndexedPrefixAdapters,
     IndexedSuffixAdapters,
 )
@@ -288,6 +289,14 @@ def test_suffix_match_with_n_wildcard_in_read():
     assert match is not None and (4, 11) == (match.rstart, match.rstop)
     match = adapter.match_to("TTTTACGTCNC")
     assert match is not None and (4, 11) == (match.rstart, match.rstop)
+
+
+def test_multiple_adapters():
+    a1 = BackAdapter("GTAGTCCCGC")
+    a2 = BackAdapter("GTAGTCCCCC")
+    ma = MultipleAdapters([a1, a2])
+    match = ma.match_to("ATACCCCTGTAGTCCCC")
+    assert match.adapter is a2
 
 
 def test_indexed_prefix_adapters():

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -9,8 +9,8 @@ from cutadapt.adapters import (
     PrefixAdapter,
     SuffixAdapter,
     LinkedAdapter,
-    MultiPrefixAdapter,
-    MultiSuffixAdapter,
+    IndexedPrefixAdapters,
+    IndexedSuffixAdapters,
 )
 
 
@@ -290,52 +290,52 @@ def test_suffix_match_with_n_wildcard_in_read():
     assert match is not None and (4, 11) == (match.rstart, match.rstop)
 
 
-def test_multi_prefix_adapter():
+def test_indexed_prefix_adapters():
     adapters = [
         PrefixAdapter("GAAC", indels=False),
         PrefixAdapter("TGCT", indels=False),
     ]
-    ma = MultiPrefixAdapter(adapters)
+    ma = IndexedPrefixAdapters(adapters)
     match = ma.match_to("GAACTT")
     assert match.adapter is adapters[0]
     match = ma.match_to("TGCTAA")
     assert match.adapter is adapters[1]
 
 
-def test_multi_prefix_adapter_incorrect_type():
+def test_indexed_prefix_adapters_incorrect_type():
     with pytest.raises(ValueError):
-        MultiPrefixAdapter([
+        IndexedPrefixAdapters([
             PrefixAdapter("GAAC", indels=False),
             SuffixAdapter("TGCT", indels=False),
         ])
 
 
-def test_multi_suffix_adapter():
+def test_indexed_suffix_adapters():
     adapters = [
         SuffixAdapter("GAAC", indels=False),
         SuffixAdapter("TGCT", indels=False),
     ]
-    ma = MultiSuffixAdapter(adapters)
+    ma = IndexedSuffixAdapters(adapters)
     match = ma.match_to("TTGAAC")
     assert match.adapter is adapters[0]
     match = ma.match_to("AATGCT")
     assert match.adapter is adapters[1]
 
 
-def test_multi_suffix_adapter_incorrect_type():
+def test_indexed_suffix_adapters_incorrect_type():
     with pytest.raises(ValueError):
-        MultiSuffixAdapter([
+        IndexedSuffixAdapters([
             SuffixAdapter("GAAC", indels=False),
             PrefixAdapter("TGCT", indels=False),
         ])
 
 
-def test_multi_prefix_adapter_with_indels():
+def test_indexed_prefix_adapters_with_indels():
     adapters = [
         PrefixAdapter("GTAC", max_errors=1, indels=True),
         PrefixAdapter("TGCT", max_errors=1, indels=True),
     ]
-    ma = MultiPrefixAdapter(adapters)
+    ma = IndexedPrefixAdapters(adapters)
     match = ma.match_to("GATACGGG")
     assert match.adapter is adapters[0]
     match = ma.match_to("TAGCTAA")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2,9 +2,16 @@ import pytest
 
 from dnaio import Sequence
 from cutadapt.adapters import (
-    RemoveAfterMatch, FrontAdapter, BackAdapter, PrefixAdapter, SuffixAdapter, LinkedAdapter,
-    MultiPrefixAdapter, MultiSuffixAdapter,
-    )
+    RemoveBeforeMatch,
+    RemoveAfterMatch,
+    FrontAdapter,
+    BackAdapter,
+    PrefixAdapter,
+    SuffixAdapter,
+    LinkedAdapter,
+    MultiPrefixAdapter,
+    MultiSuffixAdapter,
+)
 
 
 def test_back_adapter_absolute_number_of_errors():

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -340,3 +340,14 @@ def test_multi_prefix_adapter_with_indels():
     assert match.adapter is adapters[0]
     match = ma.match_to("TAGCTAA")
     assert match.adapter is adapters[1]
+
+
+def test_multi_prefix_adapter_with_n_wildcard():
+    a1 = PrefixAdapter("GGTCCAGA", max_errors=1, indels=False)
+    adapters = [a1]
+    ma = MultiPrefixAdapter(adapters)
+    result = ma.match_to("GNTCCAGAAGAT")
+    assert isinstance(result, RemoveBeforeMatch)
+    assert (result.rstart, result.rstop) == (0, 8)
+    assert result.errors == 1
+    assert result.matches == 7

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -321,3 +321,15 @@ def test_multi_suffix_adapter_incorrect_type():
             SuffixAdapter("GAAC", indels=False),
             PrefixAdapter("TGCT", indels=False),
         ])
+
+
+def test_multi_prefix_adapter_with_indels():
+    adapters = [
+        PrefixAdapter("GTAC", max_errors=1, indels=True),
+        PrefixAdapter("TGCT", max_errors=1, indels=True),
+    ]
+    ma = MultiPrefixAdapter(adapters)
+    match = ma.match_to("GATACGGG")
+    assert match.adapter is adapters[0]
+    match = ma.match_to("TAGCTAA")
+    assert match.adapter is adapters[1]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -351,12 +351,13 @@ def test_indexed_prefix_adapters_with_indels():
     assert match.adapter is adapters[1]
 
 
-def test_multi_prefix_adapter_with_n_wildcard():
-    a1 = PrefixAdapter("GGTCCAGA", max_errors=1, indels=False)
-    adapters = [a1]
-    ma = MultiPrefixAdapter(adapters)
-    result = ma.match_to("GNTCCAGAAGAT")
-    assert isinstance(result, RemoveBeforeMatch)
-    assert (result.rstart, result.rstop) == (0, 8)
-    assert result.errors == 1
-    assert result.matches == 7
+def test_indexed_prefix_adapters_with_n_wildcard():
+    sequence = "GGTCCAGA"
+    ma = IndexedPrefixAdapters([PrefixAdapter(sequence, max_errors=1, indels=False)])
+    for i in range(len(sequence)):
+        t = sequence[:i] + "N" + sequence[i+1:] + "TGCT"
+        result = ma.match_to(t)
+        assert isinstance(result, RemoveBeforeMatch)
+        assert (result.rstart, result.rstop) == (0, 8)
+        assert result.errors == 1
+        assert result.matches == 7

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -5,7 +5,10 @@ from cutadapt.align import (
     PrefixComparer,
     SuffixComparer,
     hamming_sphere,
+    edit_environment,
     SEMIGLOBAL,
+    edit_distance,
+    naive_edit_environment,
 )
 from cutadapt.adapters import Where
 
@@ -267,3 +270,29 @@ def test_hamming_sphere(sk):
     assert len(result) == 3 ** k * binomial(len(s), k)
     for t in result:
         assert hamming_distance(s, t) == k
+
+
+@pytest.mark.parametrize("sk", [
+    ('', 0),
+    ('A', 0),
+    ('AAA', 1),
+    ('ACC', 2),
+    ('TCATTA', 3),
+    ('AAAAAAAA', 1),
+    # skip these since the naive function is very slow
+    # ('A'*10, 2),
+    # ('A'*10, 3),
+    # ('A'*15, 2),
+    # ('A'*6, 4),
+])
+def test_edit_environment(sk):
+    s, k = sk
+    result = list(edit_environment(s, k))
+    strings, distances, matches = zip(*result)
+    naive = set(naive_edit_environment(s, k))
+    assert len(set(strings)) == len(strings)
+    assert set(strings) == naive
+    for t, dist, m in result:
+        assert edit_distance(s, t) == dist
+        assert m <= len(s), (s, t, dist)
+        assert m <= len(t), (s, t, dist)

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -700,7 +700,7 @@ def test_adapter_order(run):
 
 def test_reverse_complement_normalized(run):
     run(
-        "--revcomp -g ^TTATTTGTCT -g ^TCCGCACTGG",
+        "--revcomp --no-index -g ^TTATTTGTCT -g ^TCCGCACTGG",
         "revcomp-single-normalize.fastq",
         "revcomp.1.fastq",
     )
@@ -711,6 +711,7 @@ def test_reverse_complement_and_info_file(run, tmp_path, cores):
     run(
         [
             "--revcomp",
+            "--no-index",
             "-g",
             "^TTATTTGTCT",
             "-g",

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -57,7 +57,7 @@ def test_shortener():
 def test_adapter_cutter():
     a1 = BackAdapter("GTAGTCCCGC")
     a2 = BackAdapter("GTAGTCCCCC")
-    match = AdapterCutter.best_match([a1, a2], Sequence("name", "ATACCCCTGTAGTCCCC"))
+    match = AdapterCutter.best_match([a1, a2], "ATACCCCTGTAGTCCCC")
     assert match.adapter is a2
 
 

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dnaio import Sequence
-from cutadapt.adapters import BackAdapter, PrefixAdapter, MultiPrefixAdapter
+from cutadapt.adapters import BackAdapter, PrefixAdapter, IndexedPrefixAdapters
 from cutadapt.modifiers import (UnconditionalCutter, NEndTrimmer, QualityTrimmer,
     Shortener, AdapterCutter, PairedAdapterCutter, ModificationInfo)
 
@@ -67,7 +67,7 @@ def test_adapter_cutter_indexing():
     a3 = PrefixAdapter("GGAC", max_errors=1, indels=False)
     ac = AdapterCutter([a1, a2, a3])
     assert len(ac.adapters) == 1
-    assert isinstance(ac.adapters[0], MultiPrefixAdapter)
+    assert isinstance(ac.adapters[0], IndexedPrefixAdapters)
 
     ac = AdapterCutter([a1, a2, a3], index=False)
     assert ac.adapters == [a1, a2, a3]

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -69,6 +69,9 @@ def test_adapter_cutter_indexing():
     assert len(ac.adapters) == 1
     assert isinstance(ac.adapters[0], MultiPrefixAdapter)
 
+    ac = AdapterCutter([a1, a2, a3], index=False)
+    assert ac.adapters == [a1, a2, a3]
+
 
 @pytest.mark.parametrize("action,expected_trimmed1,expected_trimmed2", [
     (None, "CCCCGGTTAACCCC", "TTTTAACCGGTTTT"),

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dnaio import Sequence
+from cutadapt.adapters import BackAdapter, PrefixAdapter, MultiPrefixAdapter
 from cutadapt.modifiers import (UnconditionalCutter, NEndTrimmer, QualityTrimmer,
     Shortener, AdapterCutter, PairedAdapterCutter, ModificationInfo)
 
@@ -54,11 +55,19 @@ def test_shortener():
 
 
 def test_adapter_cutter():
-    from cutadapt.adapters import BackAdapter
     a1 = BackAdapter("GTAGTCCCGC")
     a2 = BackAdapter("GTAGTCCCCC")
     match = AdapterCutter.best_match([a1, a2], Sequence("name", "ATACCCCTGTAGTCCCC"))
     assert match.adapter is a2
+
+
+def test_adapter_cutter_indexing():
+    a1 = PrefixAdapter("ACGAT", max_errors=1, indels=False)
+    a2 = PrefixAdapter("CGATA", max_errors=1, indels=False)
+    a3 = PrefixAdapter("GGAC", max_errors=1, indels=False)
+    ac = AdapterCutter([a1, a2, a3])
+    assert len(ac.adapters) == 1
+    assert isinstance(ac.adapters[0], MultiPrefixAdapter)
 
 
 @pytest.mark.parametrize("action,expected_trimmed1,expected_trimmed2", [

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -54,13 +54,6 @@ def test_shortener():
     assert shortener(read, ModificationInfo(read)) == read
 
 
-def test_adapter_cutter():
-    a1 = BackAdapter("GTAGTCCCGC")
-    a2 = BackAdapter("GTAGTCCCCC")
-    match = AdapterCutter.best_match([a1, a2], "ATACCCCTGTAGTCCCC")
-    assert match.adapter is a2
-
-
 def test_adapter_cutter_indexing():
     a1 = PrefixAdapter("ACGAT", max_errors=1, indels=False)
     a2 = PrefixAdapter("CGATA", max_errors=1, indels=False)
@@ -70,7 +63,7 @@ def test_adapter_cutter_indexing():
     assert isinstance(ac.adapters[0], IndexedPrefixAdapters)
 
     ac = AdapterCutter([a1, a2, a3], index=False)
-    assert ac.adapters == [a1, a2, a3]
+    assert len(ac.adapters) == 3
 
 
 @pytest.mark.parametrize("action,expected_trimmed1,expected_trimmed2", [
@@ -80,7 +73,6 @@ def test_adapter_cutter_indexing():
     ("mask", "CCCCNNNNNNNNNN", "TTTTNNNNNNNNNN")
 ])
 def test_paired_adapter_cutter_actions(action, expected_trimmed1, expected_trimmed2):
-    from cutadapt.adapters import BackAdapter
     a1 = BackAdapter("GGTTAA")
     a2 = BackAdapter("AACCGG")
     s1 = Sequence("name", "CCCCGGTTAACCCC")


### PR DESCRIPTION
This adds an `edit_environment()` function, which generates all possible strings that are within a given edit distance from a target string, similar to the hamming_environment() function that is already used for the `--no-indels` case. This allows us to build the index even when indels are allowed.



To Do:
- [ ] If there are wildcard characters (`N`) in the read, the regular alignment function will find the adapter, but this will fail
- [ ] The `naive_edit_environment` function is actually faster than the more sophisticated `edit_environment` one. To use it, it needs to also return the number of matches
- [ ] Documentation
- [ ] Changelog