### PR TITLE
Add support for dumping statistics in JSON format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 development version
 -------------------
 
+* Add preliminary support for dumping statistics in JSON format using ``--json``.
 * Add option ``-Q``, which allows to specify a quality-trimming threshold for R2 that is
   different from the one for R1.
 * :issue:`524`: Fix a memory leak when using ``--info-file`` with multiple cores.

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -2051,6 +2051,7 @@ Cutadapt supports the following options to deal with ``N`` bases in your reads:
     quality trimming: ``N`` bases typically also have a low quality value
     associated with them.
 
+.. _cutadapt-s-output:
 
 Cutadapt's output
 =================
@@ -2103,7 +2104,7 @@ starts with something like this::
 
     Sequence: 'ACGTACGTACGTTAGCTAGC'; Length: 20; Trimmed: 2402 times.
 
-The meaning of this should be obvious. If option ``--revcomp`` was used,
+If option ``--revcomp`` was used,
 this line will additionally contain something like ``Reverse-complemented:
 984 times``. This describes how many times of the 2402 total times the
 adapter was found on the reverse complement of the read.
@@ -2182,6 +2183,94 @@ an error. In that case, it may look like this::
 We can see that no matches longer than 12 have zero errors. In this
 case, it indicates that the 13th base of the given adapter sequence is
 incorrect.
+
+JSON report
+-----------
+
+With ``--json=filename.cutadapt.json``, a report in JSON format is written to a separate file.
+
+* ``tag`` is always ``Cutadapt report``.
+* ``schema_version`` is 0 for now. If backwards incompatible changes to the schema are necessary,
+  this will be incremented.
+* Keys only relevant for paired-end data or when using certain command-line options are
+  always included, but when unused, get a value of ``null``.
+* For adapters that allow partial matches, ``error_lengths`` describes the lengths up to which
+  0, 1, 2 etc. errors are allowed. ``[9, 16]``: 0 errors up to a match of length 9, 1 error up to
+  a match of length 16. The last number in this list is the length of the adapter sequence.
+* ``dominant_adjacent_base`` is set to the appropriate nucleotide if the
+  :ref:`report warns <warnbase>`: "The adapter is preceded by "x" extremely often."
+  This is ``null`` if no such warning was printed.
+* For paired-end data, numbers in the ``read_counts`` section are the number of *read pairs*.
+* ``basepair_counts``
+
+Example (slightly reformatted) ::
+
+    {
+      "tag": "Cutadapt report",
+      "schema_version": 0,
+      "cutadapt_version": "3.5",
+      "python_version": "3.8.5",
+      "command_line_arguments": [
+        "--json=sample1.cutadapt.json",
+        "-q", "10",
+        "-m", "40",
+        "-a", "AACCGGTTAACCGGTT",
+        "-o", "/dev/null",
+        "sample1.fastq.gz"
+      ],
+      "cores": 1,
+      "input": {
+        "path1": "input.fastq.gz",
+        "path2": null,
+        "paired": false,
+        "interleaved": false
+      },
+      "read_counts": {
+        "input": 1000000,
+        "too_short": 18380,
+        "too_long": null,
+        "too_many_n": null,
+        "too_many_expected_errors": null,
+        "casava_filtered": null,
+        "output": 981620,
+        "reverse_complemented": null,
+        "read1_with_adapter": 233500,
+        "read2_with_adapter": null
+      },
+      "basepair_counts": {
+        "input": 101000000,
+        "input_read1": 101000000,
+        "input_read2": null,
+        "quality_trimmed": 7560458,
+        "quality_trimmed_read1": 7560458,
+        "quality_trimmed_read2": null,
+        "output": 92865797,
+        "output_read1": 92865797,
+        "output_read2": null
+      },
+      "adapter_statistics_read1": [
+        {
+          "name": "1",
+          "type": "regular 3'",
+          "specification": "AACCGGTTAACCGGTT",
+          "on_reverse_complement": 0,
+          "total_trimmed_reads": 233500,
+          "ends": [
+            {
+              "which_end": "three_prime",
+              "error_rate": 0.1,
+              "error_lengths": [9, 16],
+              "trimmed_reads": 233500,
+              "dominant_adjacent_base": "A"
+            }
+          ]
+        }
+      ],
+      "adapter_statistics_read2": null
+    }
+
+
+.. versionadded: 3.5
 
 
 .. _info-file:

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -1036,7 +1036,8 @@ def json_report(
     gc_content: float,
 ) -> Dict:
     d = {
-        "tag": "Cutadapt report v1",
+        "tag": "Cutadapt report",
+        "schema_version": 0,
         "cutadapt_version": __version__,
         "python_version": platform.python_version(),
         "command_line_arguments": cmdlineargs,

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -362,6 +362,10 @@ class Adapter(Matchable, ABC):
     description = "adapter with one component"  # this is overriden in subclasses
 
     @abstractmethod
+    def spec(self) -> str:
+        """Return string representation of this adapter"""
+
+    @abstractmethod
     def create_statistics(self) -> AdapterStatistics:
         pass
 
@@ -513,6 +517,9 @@ class FrontAdapter(SingleAdapter):
             return None
         return RemoveBeforeMatch(*alignment, adapter=self, sequence=sequence)
 
+    def spec(self) -> str:
+        return f"{self.sequence}..."
+
 
 class BackAdapter(SingleAdapter):
     """A 3' adapter"""
@@ -540,6 +547,9 @@ class BackAdapter(SingleAdapter):
         if alignment is None:
             return None
         return RemoveAfterMatch(*alignment, adapter=self, sequence=sequence)
+
+    def spec(self) -> str:
+        return f"{self.sequence}"
 
 
 class AnywhereAdapter(SingleAdapter):
@@ -573,6 +583,9 @@ class AnywhereAdapter(SingleAdapter):
             match = RemoveAfterMatch(*alignment, adapter=self, sequence=sequence)  # type: ignore
         return match
 
+    def spec(self) -> str:
+        return f"...{self.sequence}..."
+
 
 class NonInternalFrontAdapter(FrontAdapter):
     """A non-internal 5' adapter"""
@@ -593,6 +606,9 @@ class NonInternalFrontAdapter(FrontAdapter):
         if alignment is None:
             return None
         return RemoveBeforeMatch(*alignment, adapter=self, sequence=sequence)  # type: ignore
+
+    def spec(self) -> str:
+        return f"X{self.sequence}..."
 
 
 class NonInternalBackAdapter(BackAdapter):
@@ -615,6 +631,9 @@ class NonInternalBackAdapter(BackAdapter):
             return None
         return RemoveAfterMatch(*alignment, adapter=self, sequence=sequence)  # type: ignore
 
+    def spec(self) -> str:
+        return f"{self.sequence}X"
+
 
 class PrefixAdapter(NonInternalFrontAdapter):
     """An anchored 5' adapter"""
@@ -634,6 +653,9 @@ class PrefixAdapter(NonInternalFrontAdapter):
         else:
             return self._make_aligner(Where.PREFIX.value)
 
+    def spec(self) -> str:
+        return f"^{self.sequence}..."
+
 
 class SuffixAdapter(NonInternalBackAdapter):
     """An anchored 3' adapter"""
@@ -652,6 +674,9 @@ class SuffixAdapter(NonInternalBackAdapter):
             )
         else:
             return self._make_aligner(Where.SUFFIX.value)
+
+    def spec(self) -> str:
+        return f"{self.sequence}$"
 
 
 class LinkedMatch(Match):
@@ -789,6 +814,9 @@ class LinkedAdapter(Adapter):
     @property
     def remove(self):
         return None
+
+    def spec(self) -> str:
+        return f"{self.front_adapter.spec()}...{self.back_adapter.spec()}"
 
 
 class MultipleAdapters(Matchable):

--- a/src/cutadapt/pipeline.py
+++ b/src/cutadapt/pipeline.py
@@ -700,7 +700,7 @@ class PipelineRunner(ABC):
         self._progress = progress
 
     @abstractmethod
-    def run(self):
+    def run(self) -> Statistics:
         pass
 
     @abstractmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from utils import assert_files_equal, datapath, cutpath
 from cutadapt.__main__ import main
@@ -14,6 +16,7 @@ def run(tmp_path):
     def _run(params, expected, inpath) -> Statistics:
         if type(params) is str:
             params = params.split()
+        params += ["--json", os.fspath(tmp_path / "stats.cutadapt.json")]
         tmp_fastaq = tmp_path / expected
         params += ['-o', tmp_fastaq]
         params += [datapath(inpath)]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -21,9 +21,9 @@ def test_run_as_module():
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Perhaps this can be fixed")
-def test_standard_input_pipe(tmpdir, cores):
+def test_standard_input_pipe(tmp_path, cores):
     """Read FASTQ from standard input"""
-    out_path = str(tmpdir.join("out.fastq"))
+    out_path = os.fspath(tmp_path / "out.fastq")
     in_path = datapath("small.fastq")
     # Simulate that no file name is available for stdin
     with subprocess.Popen(["cat", in_path], stdout=subprocess.PIPE) as cat:
@@ -38,9 +38,9 @@ def test_standard_input_pipe(tmpdir, cores):
     assert_files_equal(cutpath("small.fastq"), out_path)
 
 
-def test_standard_output(tmpdir, cores):
+def test_standard_output(tmp_path, cores):
     """Write FASTQ to standard output (not using --output/-o option)"""
-    out_path = str(tmpdir.join("out.fastq"))
+    out_path = os.fspath(tmp_path / "out.fastq")
     with open(out_path, "w") as out_file:
         py = subprocess.Popen([
             sys.executable, "-m", "cutadapt", "--cores", str(cores),
@@ -50,10 +50,10 @@ def test_standard_output(tmpdir, cores):
     assert_files_equal(cutpath("small.fastq"), out_path)
 
 
-def test_explicit_standard_output(tmpdir, cores):
+def test_explicit_standard_output(tmp_path, cores):
     """Write FASTQ to standard output (using "-o -")"""
 
-    out_path = str(tmpdir.join("out.fastq"))
+    out_path = os.fspath(tmp_path / "out.fastq")
     with open(out_path, "w") as out_file:
         py = subprocess.Popen([
             sys.executable, "-m", "cutadapt", "-o", "-", "--cores", str(cores),
@@ -63,10 +63,10 @@ def test_explicit_standard_output(tmpdir, cores):
     assert_files_equal(cutpath("small.fastq"), out_path)
 
 
-def test_force_fasta_output(tmpdir, cores):
+def test_force_fasta_output(tmp_path, cores):
     """Write FASTA to standard output even on FASTQ input"""
 
-    out_path = str(tmpdir.join("out.fasta"))
+    out_path = os.fspath(tmp_path / "out.fasta")
     with open(out_path, "w") as out_file:
         py = subprocess.Popen([
             sys.executable, "-m", "cutadapt", "--fasta", "-o", "-", "--cores", str(cores),

--- a/tests/test_paired.py
+++ b/tests/test_paired.py
@@ -15,6 +15,7 @@ def run_paired(tmp_path):
         if type(params) is str:
             params = params.split()
         params += ["--cores", str(cores), "--buffer-size=512"]
+        params += ["--json", os.fspath(tmp_path / "stats.cutadapt.json")]
         path1 = os.fspath(tmp_path / expected1)
         path2 = os.fspath(tmp_path / expected2)
         params += ["-o", path1, "-p", path2]
@@ -38,6 +39,7 @@ def run_interleaved(tmp_path):
         assert not (inpath2 and not inpath1)
         params = params.split()
         params += ["--interleaved", "--cores", str(cores), "--buffer-size=512"]
+        params += ["--json", os.fspath(tmp_path / "stats.cutadapt.json")]
         tmp1 = os.fspath(tmp_path / ("out1-" + expected1))
         params += ["-o", tmp1]
         paths = [datapath(inpath1)]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import os
 from textwrap import dedent
 import pytest
 
@@ -28,19 +29,22 @@ def test_expand_braces_fail():
             AdapterSpecification.expand_braces(expression)
 
 
-def test_parse_file_notation(tmpdir):
-    tmp_path = str(tmpdir.join('adapters.fasta'))
-    with open(tmp_path, 'w') as f:
-        f.write(dedent(""">first_name
+def test_parse_file_notation(tmp_path):
+    tmp = tmp_path / "adapters.fasta"
+    tmp.write_text(
+        dedent(
+            """>first_name
             ADAPTER1
             >second_name
             ADAPTER2
-            """))
+            """
+        )
+    )
     parser = AdapterParser(
         max_errors=0.2, min_overlap=4, read_wildcards=False,
         adapter_wildcards=False, indels=False)
 
-    adapters = list(parser.parse('file:' + tmp_path, cmdline_type='back'))
+    adapters = list(parser.parse('file:' + os.fspath(tmp), cmdline_type='back'))
     assert len(adapters) == 2
     assert adapters[0].name == 'first_name'
     assert adapters[0].sequence == 'ADAPTER1'


### PR DESCRIPTION
To do:
* [ ] `on_reverse_complement` should be `null` if `--revcomp` was not given
* [ ] `ends` needs to be restructured. For a 3' adapter, it should not show zero counts for the 5' end.
* [ ] The histogram is missing