### PR TITLE
Force xopen to use the main thread  when cores==1

### DIFF
--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -1021,11 +1021,7 @@ def warn_if_en_dashes(args):
 
 
 def estimate_compression_threads(cores: int) -> Optional[int]:
-    if cores == 1:
-        # This sets xopen in a mode were only the main thread is used.
-        # No external programs will be used.
-        return 0
-    return max(0, min(cores, 4))
+    return max(0, min(cores - 1, 4))
 
 
 def is_any_output_stdout(args):

--- a/src/cutadapt/__main__.py
+++ b/src/cutadapt/__main__.py
@@ -1021,6 +1021,10 @@ def warn_if_en_dashes(args):
 
 
 def estimate_compression_threads(cores: int) -> Optional[int]:
+    if cores == 1:
+        # This sets xopen in a mode were only the main thread is used.
+        # No external programs will be used.
+        return 0
     return max(0, min(cores, 4))
 
 


### PR DESCRIPTION
Currently cutadapt opens external programs on the default setting, thus using more than 1 core by default. Even if cores is explicitly set to 1.
Cores ==0 does not help the situation.

EDIT: As shown in many many benchmarks. There is overhead to using multithreading. The best way to utilize a cluster is to open a multitude of single threaded processes. Cutadapt is fast enough to do this in reasonable time. 

EDIT2: A hidden flag that explicitly sets the xopen threads could be an alternative.