### PR TITLE
Improve error message when using min_overlap with a non-linked adapter.

### DIFF
--- a/src/cutadapt/parser.py
+++ b/src/cutadapt/parser.py
@@ -230,7 +230,8 @@ class AdapterSpecification:
                 "Placement restrictions (with X, ^, $) not supported for 'anywhere' (-b) adapters")
 
         if "min_overlap" in parameters and restriction == "anchored":
-            raise ValueError("Setting min_overlap/o for anchored adapters is not possible")
+            raise ValueError("Setting min_overlap/o for anchored adapters is not possible "
+                             "when using a non-linked adapter. Use overlap/O instead.")
 
         if parameters.get("min_overlap", 0) > len(spec):
             raise ValueError(


### PR DESCRIPTION
Closes #592 