### PR TITLE
Install all packages from wheels during tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     pytest-timeout
     pytest-mock
+install_command = python -m pip install --only-binary :all: {opts} {packages}
 setenv = PYTHONDEVMODE = 1
 commands =
     coverage run -m pytest --doctest-modules --pyargs cutadapt tests


### PR DESCRIPTION
This should help us catch missing wheels on supported platforms, see #629. (No macOS wheels for dnaio available.)

This adds option `--only-binary :all:` to the `pip install` command. This also covers all the test dependencies (pytest etc.), and only listing non-test requirements would be more accurate, but the test requirements are all available as wheels, so it should be fine.

(I’m adding this now before uploading macOS wheels for dnaio to make sure that the test fails properly.)