### PR TITLE
Add kmer heuristic for faster adapter matching

### DIFF
--- a/src/cutadapt/_align.pyx
+++ b/src/cutadapt/_align.pyx
@@ -3,6 +3,8 @@ from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
 from cpython.mem cimport PyMem_Malloc, PyMem_Free, PyMem_Realloc
 from cpython.unicode cimport PyUnicode_GET_LENGTH
 
+from ._match_tables import _upper_table, _acgt_table, _iupac_table
+
 cdef extern from "Python.h":
     void * PyUnicode_DATA(object o)
     bint PyUnicode_IS_COMPACT_ASCII(object o)
@@ -26,70 +28,6 @@ ctypedef struct _Match:
     int score
     int ref_stop
     int query_stop
-
-
-def _acgt_table():
-    """
-    Return a translation table that maps A, C, G, T characters to the lower
-    four bits of a byte. Other characters (including possibly IUPAC characters)
-    are mapped to the most significant bit (0x80).
-
-    Lowercase versions are also translated, and U is treated the same as T.
-    """
-    d = dict(A=1, C=2, G=4, T=8, U=8)
-    t = bytearray([0x80]) * 256
-    for c, v in d.items():
-        t[ord(c)] = v
-        t[ord(c.lower())] = v
-    return bytes(t)
-
-
-def _iupac_table():
-    """
-    Return a translation table for IUPAC characters.
-
-    The table maps ASCII-encoded IUPAC nucleotide characters to bytes in which
-    the four least significant bits are used to represent one nucleotide each.
-
-    For the "N" wildcard, additionally the most significant bit is set (0x80),
-    which allows it to match characters that are not A, C, G or T if _acgt_table
-    was used to encode them.
-
-    Whether two encoded characters x and y match can then be checked with the
-    expression "x & y != 0".
-    """
-    A = 1
-    C = 2
-    G = 4
-    T = 8
-    iupac = dict(
-        X=0,
-        A=A,
-        C=C,
-        G=G,
-        T=T,
-        U=T,
-        R=A|G,
-        Y=C|T,
-        S=G|C,
-        W=A|T,
-        K=G|T,
-        M=A|C,
-        B=C|G|T,
-        D=A|G|T,
-        H=A|C|T,
-        V=A|C|G,
-        N=A|C|G|T + 0x80,
-    )
-    t = bytearray(b'\0') * 256
-    for c, v in iupac.items():
-        t[ord(c)] = v
-        t[ord(c.lower())] = v
-    return bytes(t)
-
-def _upper_table():
-    table = bytes(range(256)).upper()
-    return table
 
 
 cdef:

--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -4,7 +4,7 @@ class KmerFinder:
     def __init__(
         self,
         kmers_and_positions: List[Tuple[str, int, Optional[int]]],
-        ref_wildcards: bool,
-        query_wildcards: bool,
+        ref_wildcards: bool = False,
+        query_wildcards: bool = False,
     ): ...
     def kmers_present(self, __sequence: str) -> bool: ...

--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 class KmerFinder:
     def __init__(
         self,
-        kmers_and_positions: List[Tuple[str, int, Optional[int]]],
+        kmers_and_positions: List[Tuple[int, Optional[int], List[str]]],
         ref_wildcards: bool = False,
         query_wildcards: bool = False,
     ): ...

--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 class KmerFinder:
     def __init__(
         self,
-        kmers_and_positions: List[Tuple[int, Optional[int], List[str]]],
+        positions_and_kmers: List[Tuple[int, Optional[int], List[str]]],
         ref_wildcards: bool = False,
         query_wildcards: bool = False,
     ): ...

--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -3,7 +3,7 @@ from typing import List, Tuple
 class KmerFinder:
     def __init__(
         self,
-        kmers_and_offsets: List[Tuple[str, int]],
+        kmers_and_positions: List[Tuple[str, int, int]],
         ref_wildcards: bool,
         query_wildcards: bool,
     ): ...

--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -1,5 +1,10 @@
 from typing import List, Tuple
 
 class KmerFinder:
-    def __init__(self, kmers_and_offsets: List[Tuple[str, int]]): ...
+    def __init__(
+        self,
+        kmers_and_offsets: List[Tuple[str, int]],
+        ref_wildcards: bool,
+        query_wildcards: bool,
+    ): ...
     def kmers_present(self, __sequence: str) -> bool: ...

--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -1,9 +1,9 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 class KmerFinder:
     def __init__(
         self,
-        kmers_and_positions: List[Tuple[str, int, int]],
+        kmers_and_positions: List[Tuple[str, int, Optional[int]]],
         ref_wildcards: bool,
         query_wildcards: bool,
     ): ...

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -1,7 +1,7 @@
 # cython: profile=False, emit_code_comments=False, language_level=3
 
-from cpython.mem cimport PyMem_Malloc, PyMem_Free
-from libc.string cimport memset, strlen
+from cpython.mem cimport PyMem_Realloc, PyMem_Free
+from libc.string cimport memcpy, memset, strlen
 
 from cpython.unicode cimport PyUnicode_CheckExact, PyUnicode_GET_LENGTH
 from libc.stdint cimport uint8_t
@@ -17,11 +17,12 @@ cdef extern from "Python.h":
     void *PyUnicode_DATA(object o)
     bint PyUnicode_IS_COMPACT_ASCII(object o)
 
-ctypedef struct KmerEntry:
-    size_t kmer_length
+ctypedef struct KmerSearchEntry:
     size_t mask_offset
     ssize_t search_start
     ssize_t search_stop
+    bitmask_t zero_mask
+    bitmask_t found_mask
 
 
 cdef class KmerFinder:
@@ -43,77 +44,113 @@ cdef class KmerFinder:
     This has a lot of python overhead. The following code accomplishes the
     same task and allows for case-independent matching:
 
-        kmers_and_positions = [("AGA", -10, None), ("AGCATGA", 0, None)]
-        kmer_finder = KmerFinder(kmers_and_positions)
+        positions_and_kmers = [(-10, None, ["AGA"]), (0, None, ["AGCATGA"])]
+        kmer_finder = KmerFinder(positions_and_kmers)
         for sequence in sequences:
             if kmer_finder.kmers_present(sequence):
                 # do something
-                pass
+                continue
 
     This is more efficient as the kmers_present method can be applied to a lot
     of sequences and all the necessary unpacking for each kmer into C variables
     happens only once.
+    Note that multiple kmers can be given per position. Kmerfinder finds
+    all of these simultaneously using a multiple pattern matching algorithm.
     """
     cdef:
-        KmerEntry *kmer_entries
-        bitmask_t *kmer_masks
-        size_t number_of_kmers
-        readonly object kmers_and_positions
+        KmerSearchEntry *search_entries
+        bitmask_t *search_masks
+        size_t number_of_searches
+        readonly object positions_and_kmers
         readonly bint ref_wildcards
         readonly bint query_wildcards
 
-    def __cinit__(self, kmers_and_positions, ref_wildcards=False, query_wildcards=False):
-        self.kmer_masks = NULL
-        self.kmer_entries = NULL
-        self.number_of_kmers = 0
+    def __cinit__(self, positions_and_kmers, ref_wildcards=False, query_wildcards=False):
+        cdef char[64] search_word
+        self.search_masks = NULL
+        self.search_entries = NULL
+        self.number_of_searches = 0
         self.ref_wildcards = ref_wildcards
         self.query_wildcards = query_wildcards
-        number_of_entries = len(kmers_and_positions)
-        self.kmer_entries = <KmerEntry *>PyMem_Malloc(number_of_entries * sizeof(KmerEntry))
-        # for the kmers the NULL bytes also need space.
-        self.kmer_masks = <bitmask_t *>PyMem_Malloc(number_of_entries * sizeof(bitmask_t) * BITMASK_INDEX_SIZE)
-        self.number_of_kmers = number_of_entries
+        self.number_of_searches = 0
         cdef size_t mask_offset = 0
         cdef char *kmer_ptr
+        cdef size_t offset
+        cdef bitmask_t zero_mask, found_mask
         cdef Py_ssize_t kmer_length
-        for i, (kmer, start, stop) in enumerate(kmers_and_positions):
-            if not PyUnicode_CheckExact(kmer):
-                raise TypeError(f"Kmer should be a string not {type(kmer)}")
-            if not PyUnicode_IS_COMPACT_ASCII(kmer):
-                raise ValueError("Only ASCII strings are supported")
-            self.kmer_entries[i].search_start  = start
-            if stop is None:
-                stop = 0
-            self.kmer_entries[i].search_stop = stop
-            self.kmer_entries[i].mask_offset = mask_offset
-            kmer_length = PyUnicode_GET_LENGTH(kmer)
-            self.kmer_entries[i].kmer_length = kmer_length
-            kmer_ptr = <char *>PyUnicode_DATA(kmer)
-            populate_needle_mask(self.kmer_masks + mask_offset, kmer_ptr, kmer_length,
-                                 self.ref_wildcards, self.query_wildcards)
-            mask_offset += BITMASK_INDEX_SIZE
-        self.kmers_and_positions = kmers_and_positions
+        # The maximum length of words + null bytes that we can store in
+        # the bitmask array
+        cdef size_t max_total_length = sizeof(bitmask_t) * 8
+        # The maximum length of a word. Since word_length + 1 bits are needed to search.
+        cdef ssize_t max_word_length = max_total_length - 1
+
+        for (start, stop, kmers) in positions_and_kmers:
+            index = 0 
+            while index < len(kmers):
+                memset(search_word, 0, 64)
+                offset = 0
+                zero_mask = ~0
+                found_mask = 0
+                # Run an inner loop in case all words combined are larger than
+                # the maximum bitmask size. In that case we create multiple
+                # bitmasks to hold all the words.
+                while index < len(kmers):
+                    kmer = kmers[index]
+                    if not PyUnicode_CheckExact(kmer):
+                        raise TypeError(f"Kmer should be a string not {type(kmer)}")
+                    if not PyUnicode_IS_COMPACT_ASCII(kmer):
+                        raise ValueError("Only ASCII strings are supported")
+                    kmer_length = PyUnicode_GET_LENGTH(kmer)
+                    if kmer_length > max_word_length:
+                        raise ValueError(f"{kmer} of length {kmer_length} is longer "
+                                         f"than the maximum of {max_word_length}.")
+                    if (offset + kmer_length + 1) > max_total_length:
+                        break
+                    zero_mask ^= <bitmask_t>1ULL << offset
+                    kmer_ptr = <char *> PyUnicode_DATA(kmer)
+                    memcpy(search_word + offset, kmer_ptr, kmer_length)
+                    search_word[offset + kmer_length] = 0
+                    found_mask |= <bitmask_t>1ULL << (offset + kmer_length)
+                    offset = offset + kmer_length + 1
+                    index += 1
+                i = self.number_of_searches  # Save the index position for the mask and entry
+                self.number_of_searches += 1
+                self.search_entries = <KmerSearchEntry *>PyMem_Realloc(self.search_entries, self.number_of_searches * sizeof(KmerSearchEntry))
+                self.search_masks = <bitmask_t *>PyMem_Realloc(self.search_masks, self.number_of_searches * sizeof(bitmask_t) * BITMASK_INDEX_SIZE)
+                mask_offset = i * BITMASK_INDEX_SIZE
+                self.search_entries[i].search_start  = start
+                if stop is None:
+                    stop = 0
+                self.search_entries[i].search_stop = stop
+                self.search_entries[i].mask_offset = mask_offset
+                self.search_entries[i].zero_mask = zero_mask
+                self.search_entries[i].found_mask = found_mask
+                # Offset -1 because we don't count the last NULL byte
+                populate_needle_mask(self.search_masks + mask_offset, search_word, offset - 1,
+                                     self.ref_wildcards, self.query_wildcards)
+        self.positions_and_kmers = positions_and_kmers
 
     def __reduce__(self):
-        return KmerFinder, (self.kmers_and_positions, self.ref_wildcards, self.query_wildcards)
+        return KmerFinder, (self.positions_and_kmers, self.ref_wildcards, self.query_wildcards)
 
     def kmers_present(self, str sequence):
         cdef:
-            KmerEntry entry
+            KmerSearchEntry entry
             size_t i
             size_t kmer_offset
-            size_t kmer_length
+            bitmask_t zero_mask
+            bitmask_t found_mask
             ssize_t start, stop
             const bitmask_t *mask_ptr
             const char *search_ptr
-            const char *search_result
+            bint search_result
             ssize_t search_length
         if not PyUnicode_IS_COMPACT_ASCII(sequence):
             raise ValueError("Only ASCII strings are supported")
         cdef const char *seq = <char *>PyUnicode_DATA(sequence)
         cdef Py_ssize_t seq_length = PyUnicode_GET_LENGTH(sequence)
-        for i in range(self.number_of_kmers):
-            entry = self.kmer_entries[i]
+        for i in range(self.number_of_searches):
+            entry = self.search_entries[i]
             start = entry.search_start 
             stop = entry.search_stop
             if start < 0:
@@ -132,17 +169,18 @@ cdef class KmerFinder:
             if search_length <= 0:
                 continue
             search_ptr = seq + start
-            kmer_length = entry.kmer_length
-            mask_ptr = self.kmer_masks + entry.mask_offset
-            search_result = shift_or_search(search_ptr, search_length,
-                                            mask_ptr, kmer_length)
+            zero_mask = entry.zero_mask
+            found_mask = entry.found_mask
+            mask_ptr = self.search_masks + entry.mask_offset
+            search_result = shift_or_multiple_is_present(
+                search_ptr, search_length, mask_ptr, zero_mask, found_mask)
             if search_result:
                 return True
         return False
 
     def __dealloc__(self):
-        PyMem_Free(self.kmer_masks)
-        PyMem_Free(self.kmer_entries)
+        PyMem_Free(self.search_masks)
+        PyMem_Free(self.search_entries)
 
 
 cdef void set_masks(bitmask_t *needle_mask, size_t pos, const char *chars):
@@ -161,6 +199,8 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
     memset(needle_mask, 0xff, sizeof(bitmask_t) * BITMASK_INDEX_SIZE)
     for i in range(needle_length):
         c = needle[i]
+        if c == 0:
+            continue
         if c == b"A" or c == b"a":
             set_masks(needle_mask, i, "Aa")
             if query_wildcards:
@@ -244,20 +284,22 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
                 needle_mask[<uint8_t>c] &= ~(<bitmask_t>1ULL << i)
 
 
-cdef const char *shift_or_search(const char *haystack, size_t haystack_length,
-                           const bitmask_t *needle_mask, size_t needle_length):
+cdef bint shift_or_multiple_is_present(
+    const char *haystack,
+    size_t haystack_length,
+    const bitmask_t *needle_mask,
+    bitmask_t zero_mask,
+    bitmask_t found_mask):
     cdef:
-        bitmask_t R = ~1
+        bitmask_t R = zero_mask
         size_t i
-
-    if needle_length == 0:
-        return haystack
 
     for i in range(haystack_length):
         # Update the bit array
         R |= needle_mask[<uint8_t>haystack[i]]
         R <<= 1
-        if (0 == (R & (<bitmask_t>1ULL << needle_length))):
-            return (haystack + i - needle_length) + 1
+        R &= zero_mask
+        if ((R & found_mask) != found_mask):
+            return True
 
-    return NULL
+    return False

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -51,8 +51,6 @@ cdef class KmerFinder:
         self.number_of_kmers = 0
         self.ref_wildcards = ref_wildcards
         self.query_wildcards = query_wildcards
-        kmers = [kmer for kmer, _ in kmers_and_positions]
-        kmer_total_length = sum(len(kmer) for kmer in kmers)
         number_of_entries = len(kmers_and_positions)
         self.kmer_entries = <KmerEntry *>PyMem_Malloc(number_of_entries * sizeof(KmerEntry))
         # for the kmers the NULL bytes also need space.
@@ -69,7 +67,7 @@ cdef class KmerFinder:
             self.kmer_entries[i].search_start  = start
             if stop is None:
                 stop = 0
-            self.kmer_intries[i].search_stop = stop
+            self.kmer_entries[i].search_stop = stop
             self.kmer_entries[i].mask_offset = mask_offset
             kmer_length = PyUnicode_GET_LENGTH(kmer)
             self.kmer_entries[i].kmer_length = kmer_length

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: profile=False, emit_code_comments=False, language_level=3
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.string cimport memset, strlen

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -9,8 +9,6 @@ from libc.stdint cimport uint8_t
 # Dnaio conveniently ensures that all sequences are ASCII only.
 DEF BITMASK_INDEX_SIZE = 128
 
-# Make bitmask type definable. size_t is the largest unsigned integer available
-# to the machine.
 ctypedef size_t bitmask_t
 
 cdef extern from "Python.h":

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -158,7 +158,7 @@ cdef class KmerFinder:
             elif start > seq_length:
                 continue
             if stop < 0:
-                step = seq_length + stop
+                stop = seq_length + stop
                 if stop <= 0:  # No need to search
                     continue
             elif stop == 0:

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -103,13 +103,13 @@ cdef class KmerFinder:
                 start = seq_length + start
                 if start < 0:
                     start = 0
-            if start > seq_length:
+            elif start > seq_length:
                 continue
             if stop < 0:
                 step = seq_length + stop
                 if stop <= 0:  # No need to search
                     continue
-            if stop == 0:
+            elif stop == 0:
                 stop = seq_length
             search_length = stop - start
             if search_length <= 0:

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -229,7 +229,7 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
             else:  # N matches literally everything except \00
                 for j in range(1,128):
                     needle_mask[j] &= ~(<bitmask_t>1ULL << i)
-        elif query_wildcards:
+        elif query_wildcards and not ref_wildcards:
             # All non-AGCT characters match to N
             set_masks(needle_mask, i, "Nn")
         elif ref_wildcards:

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -24,14 +24,20 @@ cdef class KmerFinder:
     Find kmers in strings. To replace the following code:
 
         kmers_and_positions = [("AGA", -10, None), ("AGCATGA", 0, None)]
-        for kmer, start, stop in kmers_and_positions:
-            sequence.find(kmer, start, stop)
+        for sequence in sequences:
+            for kmer, start, stop in kmers_and_positions:
+                if sequence.find(kmer, start, stop) != -1:
+                    # do something
+                    pass
 
     This has a lot of python overhead. The following code is equivalent:
 
         kmers_and_positions = [("AGA", -10, None), ("AGCATGA", 0, None)]
         kmer_finder = KmerFinder(kmers_and_positions)
-        kmer_finder.kmers_present(sequence)
+        for sequence in sequences:
+            if kmer_finder.kmers_present(sequence):
+                # do something
+                pass
 
     This is more efficient as the kmers_present method can be applied to a lot
     of sequences and all the necessary unpacking for each kmer into C variables

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -160,6 +160,42 @@ cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_lengt
             set_masks(needle_mask, i, "CcTt")
             if query_wildcards:
                 set_masks(needle_mask, i, "YBHNybhn")
+        elif (c == b"S" or c == b"s") and ref_wildcards:
+            set_masks(needle_mask, i, "GgCc")
+            if query_wildcards:
+                set_masks(needle_mask, i, "SBVNsbvn")
+        elif (c == b"W" or c == b"w") and ref_wildcards:
+            set_masks(needle_mask, i, "AaTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "WDHNwdhn")
+        elif (c == b"K" or c == b"k") and ref_wildcards:
+            set_masks(needle_mask, i, "GgTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "KBDNkbdn")
+        elif (c == b"M" or c == b"m") and ref_wildcards:
+            set_masks(needle_mask, i, "AaCc")
+            if query_wildcards:
+                set_masks(needle_mask, i, "MHVNmhvn")
+        elif (c == b"B" or  c == b"b") and ref_wildcards:
+            set_masks(needle_mask, i, "CcGgTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "BNbn")
+        elif (c == b"D" or c == b"d") and ref_wildcards:
+            set_masks(needle_mask, i, "AaGgTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "DNdn")
+        elif (c == b"H" or c == b"h") and ref_wildcards:
+            set_masks(needle_mask, i, "AaCcTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "HNhn")
+        elif (c == b"V" or c == b"v") and ref_wildcards:
+            set_masks(needle_mask, i, "AaCcGg")
+            if query_wildcards:
+                set_masks(needle_mask, i, "VNvn")
+        elif (c == b"N" or c == b"n") and ref_wildcards:
+            set_masks(needle_mask, i, "AaCcGgTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "URYSWKMBDHVNuryswkmbdhvn")
         else:
             needle_mask[<uint8_t>c] &= ~(1UL << i)
 

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -229,13 +229,19 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
             else:  # N matches literally everything except \00
                 for j in range(1,128):
                     needle_mask[j] &= ~(<bitmask_t>1ULL << i)
+        elif query_wildcards:
+            # All non-AGCT characters match to N
+            set_masks(needle_mask, i, "Nn")
+        elif ref_wildcards:
+            # ref and query wildcards are True. Perform proper IUPAC matching.
+            # All unknown characters do not match.
+            pass
         else:
-            if (not ref_wildcards and not query_wildcards):
-                if chr(c).isalpha():
-                    bothcase = chr(c).lower() + chr(c).upper()
-                    set_masks(needle_mask, i, bothcase.encode("ascii"))
-                else:
-                    needle_mask[<uint8_t>c] &= ~(<bitmask_t>1ULL << i)
+            if chr(c).isalpha():
+                bothcase = chr(c).lower() + chr(c).upper()
+                set_masks(needle_mask, i, bothcase.encode("ascii"))
+            else:
+                needle_mask[<uint8_t>c] &= ~(<bitmask_t>1ULL << i)
 
 
 cdef const char *shift_or_search(const char *haystack, size_t haystack_length,

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -135,7 +135,7 @@ cdef void set_masks(size_t *needle_mask, size_t pos, char *chars):
         needle_mask[<uint8_t>chars[i]] &= ~(1UL << pos)
 
 cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_length,
-                          bint ref_wildcards, query_wildcards):
+                          bint ref_wildcards, bint query_wildcards):
     cdef size_t i
     cdef char c
     if needle_length > (sizeof(size_t) * 8 - 1):
@@ -207,7 +207,12 @@ cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_lengt
             if query_wildcards:  # Proper IUPAC matching
                 set_masks(needle_mask, i, "URYSWKMBDHVNuryswkmbdhvn")
             else:  # N matches literally everything except \00
-                set_masks(needle_mask, i, bytes(range(1, 128)))
+                set_masks(needle_mask, i,
+                          "\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e"
+                          "\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a"
+                          "\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<="
+                          ">?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmno"
+                          "pqrstuvwxyz{|}~\x7f")
         else:
             needle_mask[<uint8_t>c] &= ~(1UL << i)
 

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -186,7 +186,7 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
         elif (c == b"R" or c == b"r") and ref_wildcards:
             set_masks(needle_mask, i, "AaGg")
             if query_wildcards:
-                set_masks(needle_mask, i, "RSWKMBDHVNrswkmvdhvn")
+                set_masks(needle_mask, i, "RSWKMBDHVNrswkmbdhvn")
         elif (c == b"Y" or c == b"y") and ref_wildcards:
             set_masks(needle_mask, i, "CcTtUu")
             if query_wildcards:
@@ -198,15 +198,15 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
         elif (c == b"W" or c == b"w") and ref_wildcards:
             set_masks(needle_mask, i, "AaTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "YRWKMBDHVNyrskmbdhvn")
+                set_masks(needle_mask, i, "YRWKMBDHVNyrwkmbdhvn")
         elif (c == b"K" or c == b"k") and ref_wildcards:
             set_masks(needle_mask, i, "GgTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "YRWSKBDHVNyrskmbdhvn")
+                set_masks(needle_mask, i, "YRWSKBDHVNyrwskbdhvn")
         elif (c == b"M" or c == b"m") and ref_wildcards:
             set_masks(needle_mask, i, "AaCc")
             if query_wildcards:
-                set_masks(needle_mask, i, "YRWSMBDHVNyrskmbdhvn")
+                set_masks(needle_mask, i, "YRWSMBDHVNyrwsmbdhvn")
         elif (c == b"B" or  c == b"b") and ref_wildcards:
             set_masks(needle_mask, i, "CcGgTtUu")
             if query_wildcards:
@@ -230,11 +230,12 @@ cdef populate_needle_mask(bitmask_t *needle_mask, const char *needle, size_t nee
                 for j in range(1,128):
                     needle_mask[j] &= ~(<bitmask_t>1ULL << i)
         else:
-            if (not ref_wildcards) and chr(c).isalpha():
-                bothcase = chr(c).lower() + chr(c).upper()
-                set_masks(needle_mask, i, bothcase.encode("ascii"))
-            else:
-                needle_mask[<uint8_t>c] &= ~(<bitmask_t>1ULL << i)
+            if (not ref_wildcards and not query_wildcards):
+                if chr(c).isalpha():
+                    bothcase = chr(c).lower() + chr(c).upper()
+                    set_masks(needle_mask, i, bothcase.encode("ascii"))
+                else:
+                    needle_mask[<uint8_t>c] &= ~(<bitmask_t>1ULL << i)
 
 
 cdef const char *shift_or_search(const char *haystack, size_t haystack_length,

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -90,7 +90,7 @@ cdef class KmerFinder:
             size_t *mask_ptr
             char *search_ptr
             char *search_result
-            size_t search_length
+            ssize_t search_length
         if not PyUnicode_IS_COMPACT_ASCII(sequence):
             raise ValueError("Only ASCII strings are supported")
         cdef char *seq = <char *>PyUnicode_DATA(sequence)

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -204,9 +204,10 @@ cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_lengt
             if query_wildcards:
                 set_masks(needle_mask, i, "VNvn")
         elif (c == b"N" or c == b"n") and ref_wildcards:
-            set_masks(needle_mask, i, "AaCcGgTt")
-            if query_wildcards:
+            if query_wildcards:  # Proper IUPAC matching
                 set_masks(needle_mask, i, "URYSWKMBDHVNuryswkmbdhvn")
+            else:  # N matches literally everything except \00
+                set_masks(needle_mask, i, bytes(range(1, 128)))
         else:
             needle_mask[<uint8_t>c] &= ~(1UL << i)
 

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -18,7 +18,7 @@ cdef extern from "Python.h":
 ctypedef struct KmerSearchEntry:
     size_t mask_offset
     ssize_t search_start
-    ssize_t search_stop
+    ssize_t search_stop  # 0 if going to end of sequence.
     bitmask_t zero_mask
     bitmask_t found_mask
 
@@ -117,7 +117,7 @@ cdef class KmerFinder:
                 self.search_masks = <bitmask_t *>PyMem_Realloc(self.search_masks, self.number_of_searches * sizeof(bitmask_t) * BITMASK_INDEX_SIZE)
                 mask_offset = i * BITMASK_INDEX_SIZE
                 self.search_entries[i].search_start  = start
-                if stop is None:
+                if stop is None:  # Encode 'end of sequence' as 0.
                     stop = 0
                 self.search_entries[i].search_stop = stop
                 self.search_entries[i].mask_offset = mask_offset
@@ -161,7 +161,7 @@ cdef class KmerFinder:
                 stop = seq_length + stop
                 if stop <= 0:  # No need to search
                     continue
-            elif stop == 0:
+            elif stop == 0:  # stop == 0 means go to end of sequence.
                 stop = seq_length
             search_length = stop - start
             if search_length <= 0:

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -41,7 +41,7 @@ cdef class KmerFinder:
         KmerEntry *kmer_entries
         size_t *kmer_masks
         size_t number_of_kmers
-        object kmers_and_positions
+        readonly object kmers_and_positions
         readonly bint ref_wildcards
         readonly bint query_wildcards
 

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -148,6 +148,18 @@ cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_lengt
             set_masks(needle_mask, i, "Tt")
             if query_wildcards:
                 set_masks(needle_mask, i, "YWKBDHNywkbdhn")
+        elif (c == b"U" or c == b"u") and ref_wildcards:
+            set_masks(needle_mask, i, "TtUu")
+            if query_wildcards:
+                set_masks(needle_mask, i, "YWKBDHNywkbdhn")
+        elif (c == b"R" or c == b"r") and ref_wildcards:
+            set_masks(needle_mask, i, "AaGg")
+            if query_wildcards:
+                set_masks(needle_mask, i, "RDVNrdvn")
+        elif (c == b"Y" or c == b"y") and ref_wildcards:
+            set_masks(needle_mask, i, "CcTt")
+            if query_wildcards:
+                set_masks(needle_mask, i, "YBHNybhn")
         else:
             needle_mask[<uint8_t>c] &= ~(1UL << i)
 

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -172,46 +172,46 @@ cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_lengt
         elif (c == b"R" or c == b"r") and ref_wildcards:
             set_masks(needle_mask, i, "AaGg")
             if query_wildcards:
-                set_masks(needle_mask, i, "RDVNrdvn")
+                set_masks(needle_mask, i, "RSWKMBDHVNrswkmvdhvn")
         elif (c == b"Y" or c == b"y") and ref_wildcards:
-            set_masks(needle_mask, i, "CcTt")
+            set_masks(needle_mask, i, "CcTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "YBHNybhn")
+                set_masks(needle_mask, i, "YSWKMBDHVNyswkmbdhvn")
         elif (c == b"S" or c == b"s") and ref_wildcards:
             set_masks(needle_mask, i, "GgCc")
             if query_wildcards:
-                set_masks(needle_mask, i, "SBVNsbvn")
+                set_masks(needle_mask, i, "YRSKMBDHVNyrskmbdhvn")
         elif (c == b"W" or c == b"w") and ref_wildcards:
-            set_masks(needle_mask, i, "AaTt")
+            set_masks(needle_mask, i, "AaTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "WDHNwdhn")
+                set_masks(needle_mask, i, "YRWKMBDHVNyrskmbdhvn")
         elif (c == b"K" or c == b"k") and ref_wildcards:
-            set_masks(needle_mask, i, "GgTt")
+            set_masks(needle_mask, i, "GgTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "KBDNkbdn")
+                set_masks(needle_mask, i, "YRWSKBDHVNyrskmbdhvn")
         elif (c == b"M" or c == b"m") and ref_wildcards:
             set_masks(needle_mask, i, "AaCc")
             if query_wildcards:
-                set_masks(needle_mask, i, "MHVNmhvn")
+                set_masks(needle_mask, i, "YRWSMBDHVNyrskmbdhvn")
         elif (c == b"B" or  c == b"b") and ref_wildcards:
-            set_masks(needle_mask, i, "CcGgTt")
+            set_masks(needle_mask, i, "CcGgTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "BNbn")
+                set_masks(needle_mask, i, "RYSWKMBDHVNryswkmbdhvn")
         elif (c == b"D" or c == b"d") and ref_wildcards:
-            set_masks(needle_mask, i, "AaGgTt")
+            set_masks(needle_mask, i, "AaGgTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "DNdn")
+                set_masks(needle_mask, i, "RYSWKMBDHVNryswkmbdhvn")
         elif (c == b"H" or c == b"h") and ref_wildcards:
-            set_masks(needle_mask, i, "AaCcTt")
+            set_masks(needle_mask, i, "AaCcTtUu")
             if query_wildcards:
-                set_masks(needle_mask, i, "HNhn")
+                set_masks(needle_mask, i, "RYSWKMBDHVNryswkmbdhvn")
         elif (c == b"V" or c == b"v") and ref_wildcards:
             set_masks(needle_mask, i, "AaCcGg")
             if query_wildcards:
-                set_masks(needle_mask, i, "VNvn")
+                set_masks(needle_mask, i, "RYSWKMBDHVNryswkmbdhvn")
         elif (c == b"N" or c == b"n") and ref_wildcards:
             if query_wildcards:  # Proper IUPAC matching
-                set_masks(needle_mask, i, "URYSWKMBDHVNuryswkmbdhvn")
+                set_masks(needle_mask, i, "ACGTURYSWKMBDHVNacgturyswkmbdhvn")
             else:  # N matches literally everything except \00
                 set_masks(needle_mask, i,
                           "\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e"

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -25,7 +25,12 @@ ctypedef struct KmerEntry:
 
 cdef class KmerFinder:
     """
-    Find kmers in strings. To replace the following code:
+    Find kmers in strings. Allows case-independent and IUPAC matching.
+    ``ref_wildcards=True`` allows IUPAC characters in the kmer sequences.
+    ``query_wildcards=True`` allows IUPAC characters in the sequences fed to
+    the ``kmers_present`` method.
+
+    Replaces the following code:
 
         kmers_and_positions = [("AGA", -10, None), ("AGCATGA", 0, None)]
         for sequence in sequences:
@@ -34,7 +39,8 @@ cdef class KmerFinder:
                     # do something
                     pass
 
-    This has a lot of python overhead. The following code is equivalent:
+    This has a lot of python overhead. The following code accomplishes the
+    same task and allows for case-independent matching:
 
         kmers_and_positions = [("AGA", -10, None), ("AGCATGA", 0, None)]
         kmer_finder = KmerFinder(kmers_and_positions)

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -297,7 +297,7 @@ cdef bint shift_or_multiple_is_present(
         R |= needle_mask[<uint8_t>haystack[i]]
         R <<= 1
         R &= zero_mask
-        if ((R & found_mask) != found_mask):
+        if (R & found_mask) != found_mask:
             return True
 
     return False

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -106,7 +106,7 @@ cdef class KmerFinder:
             mask_ptr = self.kmer_masks + entry.mask_offset
             search_ptr = seq + search_offset
             search_length = seq_length - (search_ptr - seq)
-            search_result = shift_and_search(search_ptr, search_length,
+            search_result = shift_or_search(search_ptr, search_length,
                                              mask_ptr, kmer_length)
             if search_result:
                 return True
@@ -200,7 +200,7 @@ cdef populate_needle_mask(size_t *needle_mask, char *needle, size_t needle_lengt
             needle_mask[<uint8_t>c] &= ~(1UL << i)
 
 
-cdef char *shift_and_search(char *haystack, size_t haystack_length,
+cdef char *shift_or_search(char *haystack, size_t haystack_length,
                             size_t *needle_mask, size_t needle_length):
     cdef:
         size_t R = ~1

--- a/src/cutadapt/_match_tables.py
+++ b/src/cutadapt/_match_tables.py
@@ -1,0 +1,98 @@
+import operator
+
+
+def _acgt_table():
+    """
+    Return a translation table that maps A, C, G, T characters to the lower
+    four bits of a byte. Other characters (including possibly IUPAC characters)
+    are mapped to the most significant bit (0x80).
+
+    Lowercase versions are also translated, and U is treated the same as T.
+    """
+    d = dict(A=1, C=2, G=4, T=8, U=8)
+    t = bytearray([0x80]) * 256
+    for c, v in d.items():
+        t[ord(c)] = v
+        t[ord(c.lower())] = v
+    return bytes(t)
+
+
+def _iupac_table():
+    """
+    Return a translation table for IUPAC characters.
+
+    The table maps ASCII-encoded IUPAC nucleotide characters to bytes in which
+    the four least significant bits are used to represent one nucleotide each.
+
+    For the "N" wildcard, additionally the most significant bit is set (0x80),
+    which allows it to match characters that are not A, C, G or T if _acgt_table
+    was used to encode them.
+
+    Whether two encoded characters x and y match can then be checked with the
+    expression "x & y != 0".
+    """
+    A = 1
+    C = 2
+    G = 4
+    T = 8
+    iupac = dict(
+        X=0,
+        A=A,
+        C=C,
+        G=G,
+        T=T,
+        U=T,
+        R=A | G,
+        Y=C | T,
+        S=G | C,
+        W=A | T,
+        K=G | T,
+        M=A | C,
+        B=C | G | T,
+        D=A | G | T,
+        H=A | C | T,
+        V=A | C | G,
+        N=A | C | G | T + 0x80,
+    )
+    t = bytearray(b"\0") * 256
+    for c, v in iupac.items():
+        t[ord(c)] = v
+        t[ord(c.lower())] = v
+    return bytes(t)
+
+
+def _upper_table():
+    table = bytes(range(256)).upper()
+    return table
+
+
+def all_matches_generator(ref: bytes, query: bytes, comp_op):
+    for i, ref_char in enumerate(ref):
+        matches = ""
+        for j, query_char in enumerate(query):
+            if j >= 128:  # Only ASCII characters supported.
+                break
+            if bool(comp_op(ref_char, query_char)):
+                matches += chr(j)
+        # NULL byte should not match anything
+        yield matches.encode("ascii").replace(b"\00", b"")
+
+
+def matches_lookup(ref_wildcards, query_wildcards):
+    if (not ref_wildcards) and (not query_wildcards):
+        ref_table = _upper_table()
+        query_table = _upper_table()
+        comp_op = operator.eq
+    elif ref_wildcards and (not query_wildcards):
+        ref_table = _iupac_table()
+        query_table = _acgt_table()
+        comp_op = operator.and_
+    elif (not ref_wildcards) and query_wildcards:
+        ref_table = _acgt_table()
+        query_table = _iupac_table()
+        comp_op = operator.and_
+    else:
+        ref_table = _iupac_table()
+        query_table = _iupac_table()
+        comp_op = operator.and_
+    return list(all_matches_generator(ref_table, query_table, comp_op))

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -767,7 +767,7 @@ class BackAdapter(SingleAdapter):
         overlap length, maximum error rate).
         """
         # Heuristically check if an adapter may be present. If not, skip.
-        if self.adapter_heuristic and not self.adapter_heuristic(sequence.upper()):
+        if self.adapter_heuristic and not self.adapter_heuristic(sequence):
             return None
         alignment: Optional[Tuple[int, int, int, int, int, int]] = self.aligner.locate(
             sequence

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -741,13 +741,17 @@ class BackAdapter(SingleAdapter):
         super().__init__(*args, **kwargs)
         self.adapter_heuristic = None
         self.kmer_finder = None
-        if not self.adapter_wildcards and not self.read_wildcards:
+        if not self.adapter_wildcards:
             # We can do some optimization by identifying kmers that if not
             # present in the sequence prove that no adapter is present.
             kmers_and_offsets = create_kmers_and_offsets(
-                self.sequence.upper(), self.min_overlap, self.max_error_rate
+                self.sequence.upper(),
+                self.min_overlap,
+                self.max_error_rate,
             )
-            self.kmer_finder = KmerFinder(kmers_and_offsets)
+            self.kmer_finder = KmerFinder(
+                kmers_and_offsets, self.adapter_wildcards, self.read_wildcards
+            )
             self.adapter_heuristic = self.kmer_finder.kmers_present
 
     def descriptive_identifier(self) -> str:

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -741,18 +741,17 @@ class BackAdapter(SingleAdapter):
         super().__init__(*args, **kwargs)
         self.adapter_heuristic = None
         self.kmer_finder = None
-        if not self.adapter_wildcards:
-            # We can do some optimization by identifying kmers that if not
-            # present in the sequence prove that no adapter is present.
-            kmers_and_offsets = create_kmers_and_offsets(
-                self.sequence.upper(),
-                self.min_overlap,
-                self.max_error_rate,
-            )
-            self.kmer_finder = KmerFinder(
-                kmers_and_offsets, self.adapter_wildcards, self.read_wildcards
-            )
-            self.adapter_heuristic = self.kmer_finder.kmers_present
+        # We can do some optimization by identifying kmers that if not
+        # present in the sequence prove that no adapter is present.
+        kmers_and_offsets = create_kmers_and_offsets(
+            self.sequence.upper(),
+            self.min_overlap,
+            self.max_error_rate,
+        )
+        self.kmer_finder = KmerFinder(
+            kmers_and_offsets, self.adapter_wildcards, self.read_wildcards
+        )
+        self.adapter_heuristic = self.kmer_finder.kmers_present
 
     def descriptive_identifier(self) -> str:
         return "regular_three_prime"

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -751,7 +751,6 @@ class BackAdapter(SingleAdapter):
         self.kmer_finder = KmerFinder(
             kmers_and_offsets, self.adapter_wildcards, self.read_wildcards
         )
-        self.adapter_heuristic = self.kmer_finder.kmers_present
 
     def descriptive_identifier(self) -> str:
         return "regular_three_prime"
@@ -770,7 +769,7 @@ class BackAdapter(SingleAdapter):
         overlap length, maximum error rate).
         """
         # Heuristically check if an adapter may be present. If not, skip.
-        if self.adapter_heuristic and not self.adapter_heuristic(sequence):
+        if not self.kmer_finder.kmers_present(sequence):
             return None
         alignment: Optional[Tuple[int, int, int, int, int, int]] = self.aligner.locate(
             sequence

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -745,7 +745,7 @@ class RightmostFrontAdapter(FrontAdapter):
         return None if no match was found given the matching criteria (minimum
         overlap length, maximum error rate).
         """
-        if not self.kmer_finder.kmers_present(sequence):
+        if not self.kmer_finder.kmers_present(sequence[::-1]):
             return None
         alignment: Optional[Tuple[int, int, int, int, int, int]] = self.aligner.locate(
             sequence[::-1]

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -784,8 +784,6 @@ class BackAdapter(SingleAdapter):
     def __init__(self, *args, **kwargs):
         self._force_anywhere = kwargs.pop("force_anywhere", False)
         super().__init__(*args, **kwargs)
-        # We can do some optimization by identifying kmers that if not
-        # present in the sequence prove that no adapter is present.
 
     def descriptive_identifier(self) -> str:
         return "regular_three_prime"

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -808,7 +808,6 @@ class BackAdapter(SingleAdapter):
         return None if no match was found given the matching criteria (minimum
         overlap length, maximum error rate).
         """
-        # Heuristically check if an adapter may be present. If not, skip.
         if not self.kmer_finder.kmers_present(sequence):
             return None
         alignment: Optional[Tuple[int, int, int, int, int, int]] = self.aligner.locate(

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -19,7 +19,7 @@ from .align import (
     edit_environment,
     hamming_environment,
 )
-from .kmer_heuristic import create_kmers_and_positions, kmer_probability_analysis
+from .kmer_heuristic import create_positions_and_kmers, kmer_probability_analysis
 
 logger = logging.getLogger()
 
@@ -609,7 +609,7 @@ class SingleAdapter(Adapter, ABC):
     def _make_kmer_finder(
         self, back_adapter: bool, front_adapter: bool, internal: bool = True
     ) -> KmerFinder:
-        kmers_and_positions = create_kmers_and_positions(
+        positions_and_kmers = create_positions_and_kmers(
             self.sequence,
             self.min_overlap,
             self.max_error_rate,
@@ -618,9 +618,9 @@ class SingleAdapter(Adapter, ABC):
             internal,
         )
         if self._debug:
-            print(kmer_probability_analysis(kmers_and_positions))
+            print(kmer_probability_analysis(positions_and_kmers))
         return KmerFinder(
-            kmers_and_positions, self.adapter_wildcards, self.read_wildcards
+            positions_and_kmers, self.adapter_wildcards, self.read_wildcards
         )
 
     def __repr__(self):

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -744,7 +744,11 @@ class BackAdapter(SingleAdapter):
         # We can do some optimization by identifying kmers that if not
         # present in the sequence prove that no adapter is present.
         kmers_and_offsets = create_kmers_and_offsets(
-            self.sequence.upper(), self.max_error_rate, back_overlap=self.min_overlap
+            self.sequence.upper(),
+            self.min_overlap,
+            self.max_error_rate,
+            back_adapter=True,
+            front_adapter=self._force_anywhere,
         )
         self.kmer_finder = KmerFinder(
             kmers_and_offsets, self.adapter_wildcards, self.read_wildcards

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -19,7 +19,7 @@ from .align import (
     edit_environment,
     hamming_environment,
 )
-from .kmer_heuristic import create_kmers_and_positions
+from .kmer_heuristic import create_kmers_and_positions, kmer_probability_analysis
 
 logger = logging.getLogger()
 
@@ -612,6 +612,8 @@ class SingleAdapter(Adapter, ABC):
             front_adapter,
             internal,
         )
+        if self._debug:
+            print(kmer_probability_analysis(kmers_and_positions))
         return KmerFinder(
             kmers_and_positions, self.adapter_wildcards, self.read_wildcards
         )

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -737,7 +737,7 @@ class RightmostFrontAdapter(FrontAdapter):
     def _kmer_finder(self):
         self.sequence = self.sequence[::-1]
         kmer_finder = self._make_kmer_finder(
-            front_adapter=True, back_adapter=self._force_anywhere
+            back_adapter=True, front_adapter=self._force_anywhere
         )
         self.sequence = self.sequence[::-1]
         return kmer_finder

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -750,10 +750,11 @@ class RightmostFrontAdapter(FrontAdapter):
         return None if no match was found given the matching criteria (minimum
         overlap length, maximum error rate).
         """
-        if not self.kmer_finder.kmers_present(sequence[::-1]):
+        reversed_sequence = sequence[::-1]
+        if not self.kmer_finder.kmers_present(reversed_sequence):
             return None
         alignment: Optional[Tuple[int, int, int, int, int, int]] = self.aligner.locate(
-            sequence[::-1]
+            reversed_sequence
         )
         if self._debug:
             print(self.aligner.dpmatrix)

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -24,6 +24,11 @@ from .kmer_heuristic import create_kmers_and_positions, kmer_probability_analysi
 logger = logging.getLogger()
 
 
+class MockKmerFinder:
+    def kmers_present(self, sequence: str):
+        return True
+
+
 class InvalidCharacter(Exception):
     pass
 
@@ -960,6 +965,14 @@ class PrefixAdapter(NonInternalFrontAdapter):
         else:
             return self._make_aligner(Where.PREFIX.value)
 
+    def _kmer_finder(self):
+        if isinstance(self.aligner, PrefixComparer):
+            # Prefix comparer does not create a dynamic programming matrix
+            # so the heuristic will be slow and unnecessary.
+            return MockKmerFinder()
+        else:
+            return super()._kmer_finder()
+
     def spec(self) -> str:
         return f"^{self.sequence}..."
 
@@ -988,6 +1001,14 @@ class SuffixAdapter(NonInternalBackAdapter):
             )
         else:
             return self._make_aligner(Where.SUFFIX.value)
+
+    def _kmer_finder(self):
+        if isinstance(self.aligner, SuffixComparer):
+            # Suffix comparer does not create a dynamic programming matrix
+            # so the heuristic will be slow and unnecessary.
+            return MockKmerFinder()
+        else:
+            return super()._kmer_finder()
 
     def spec(self) -> str:
         return f"{self.sequence}$"

--- a/src/cutadapt/adapters.py
+++ b/src/cutadapt/adapters.py
@@ -744,9 +744,7 @@ class BackAdapter(SingleAdapter):
         # We can do some optimization by identifying kmers that if not
         # present in the sequence prove that no adapter is present.
         kmers_and_offsets = create_kmers_and_offsets(
-            self.sequence.upper(),
-            self.min_overlap,
-            self.max_error_rate,
+            self.sequence.upper(), self.max_error_rate, back_overlap=self.min_overlap
         )
         self.kmer_finder = KmerFinder(
             kmers_and_offsets, self.adapter_wildcards, self.read_wildcards

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -71,11 +71,10 @@ def find_optimal_kmers(search_sets: List[SearchSet]) -> List[Tuple[str, int]]:
     return kmers_and_offsets
 
 
-def create_kmers_and_offsets(
+def create_back_overlap_searchsets(
     adapter: str, min_overlap: int, error_rate: float
-) -> List[Tuple[str, int]]:
+) -> List[SearchSet]:
     adapter_length = len(adapter)
-    max_errors = int(adapter_length * error_rate)
     error_lengths = []
     max_error = 1
     search_sets: List[SearchSet] = []
@@ -126,9 +125,14 @@ def create_kmers_and_offsets(
         number_of_errors = i + 1
         kmer_sets = kmer_possibilities(adapter[:error_length], number_of_errors + 1)
         search_sets.append((offset, kmer_sets))
+    return search_sets
 
-    # Create kmers at least one of which should be in the read when there is a
-    # an adapter
+
+def create_kmers_and_offsets(
+    adapter: str, min_overlap: int, error_rate: float
+) -> List[Tuple[str, int]]:
+    max_errors = int(len(adapter) * error_rate)
+    search_sets = create_back_overlap_searchsets(adapter, min_overlap, error_rate)
     kmer_sets = kmer_possibilities(adapter, max_errors + 1)
     search_sets.append((0, kmer_sets))
     return find_optimal_kmers(search_sets)

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -193,7 +193,7 @@ def create_kmers_and_positions(
 
 def kmer_probability_analysis(
     kmers_and_offsets: List[Tuple[str, int, Optional[int]]], default_length: int = 150
-) -> str:
+) -> str:  # pragma: no cover  # only for debugging use
     out = io.StringIO()
     out.write(
         "kmer\tstart\tstop\tconsidered sites\thit chance by random sequence (%)\n"

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 import sys
 from typing import List, Optional, Set, Tuple
@@ -192,8 +193,9 @@ def create_kmers_and_positions(
 
 def kmer_probability_analysis(
     kmers_and_offsets: List[Tuple[str, int, Optional[int]]], default_length: int = 150
-):
-    print("kmer\tstart\tstop\tconsidered sites\thit chance by random sequence (%)")
+) -> str:
+    out = io.StringIO()
+    out.write("kmer\tstart\tstop\tconsidered sites\thit chance by random sequence (%)\n")
     accumulated_not_hit_chance = 1.0
     for kmer, start, stop in kmers_and_offsets:
         kmer_length = len(kmer)
@@ -206,9 +208,10 @@ def kmer_probability_analysis(
         single_kmer_hit_chance = 1 / 4**kmer_length
         not_hit_chance = (1 - single_kmer_hit_chance) ** considered_sites
         accumulated_not_hit_chance *= not_hit_chance
-        print(
-            f"{kmer:10}\t{start}\t{stop}\t{considered_sites}\t{(1 - not_hit_chance) * 100:.2f}"
+        out.write(
+            f"{kmer:10}\t{start}\t{stop}\t{considered_sites}\t{(1 - not_hit_chance) * 100:.2f}\n"
         )
-    print(
-        f"Chance for profile hit by random sequence: {(1 - accumulated_not_hit_chance) * 100:.2f}%"
+    out.write(
+        f"Chance for profile hit by random sequence: {(1 - accumulated_not_hit_chance) * 100:.2f}%\n"
     )
+    return out.getvalue()

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -155,12 +155,13 @@ def create_back_overlap_searchsets(
     return search_sets
 
 
-def create_kmers_and_offsets(
+def create_kmers_and_positions(
     adapter: str,
     min_overlap: int,
     error_rate: float,
     back_adapter: bool,
     front_adapter: bool,
+    internal: bool = True,
 ) -> List[Tuple[str, int, Optional[int]]]:
     max_errors = int(len(adapter) * error_rate)
     search_sets = []
@@ -183,8 +184,9 @@ def create_kmers_and_offsets(
             ]
             front_search_sets.append((0, -start, new_kmer_sets))
         search_sets.extend(front_search_sets)
-    kmer_sets = kmer_possibilities(adapter, max_errors + 1)
-    search_sets.append((0, None, kmer_sets))
+    if internal:
+        kmer_sets = kmer_possibilities(adapter, max_errors + 1)
+        search_sets.append((0, None, kmer_sets))
     return find_optimal_kmers(search_sets)
 
 

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -11,10 +11,6 @@ def kmer_possibilities(sequence: str, chunks: int) -> List[Set[str]]:
 
     Example sequence ABCDEFGH with 3 chunks. Possibilities:
     ["ABC", "DEF", "GH"]; ["ABC", "DE", "FGH"]; ["AB", "CDE", "FGH"]
-
-    :param sequence: The sequence to b
-    :param chunks:
-    :return: A list of lists with all kmers
     """
     chunk_size = len(sequence) // (chunks)
     remainder = len(sequence) % (chunks)

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -137,6 +137,20 @@ def create_positions_and_kmers(
     front_adapter: bool,
     internal: bool = True,
 ) -> List[Tuple[int, Optional[int], List[str]]]:
+    """
+    Create a set of position and words combinations where at least one of the
+    words needs to occur at its specified position. If not an alignment
+    algorithm will not be able to find a solution. This can be checked very
+    quickly and allows for skipping alignment in cases where the adapter would
+    not align anyway.
+
+    Example: looking for AAAAATTTTT with at most one error. This means either
+    AAAAA or TTTTT (or both) must be present, otherwise alignment will not
+    succeed.
+
+    This function returns the positions and the accompanying words while also
+    taking into account partial overlap for back and front adapters.
+    """
     max_errors = int(len(adapter) * error_rate)
     search_sets = []
     if back_adapter:

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -9,8 +9,8 @@ def kmer_possibilities(sequence: str, chunks: int) -> List[Set[str]]:
     """
     Partition a sequence in almost equal sized chunks. Return all possibilities.
 
-    Example sequence ABCDEFGH with 3 chunks. Possibilities:
-    ["ABC", "DEF", "GH"]; ["ABC", "DE", "FGH"]; ["AB", "CDE", "FGH"]
+    >>> kmer_possibilities("ABCDEFGH", 3)
+    [{"ABC", "DEF", "GH"}, {"ABC", "DE", "FGH"}, {"AB", "CDE", "FGH"}]
     """
     chunk_size = len(sequence) // (chunks)
     remainder = len(sequence) % (chunks)

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -131,7 +131,7 @@ def create_back_overlap_searchsets(
     # if the adapter overlaps with the end.
     min_overlap_kmer = adapter[:min_overlap]
     min_overlap_kmer_start = (
-        -(error_lengths[0] - 1) if error_lengths else -(adapter_length - 1)
+        -(error_lengths[0] - 1) if error_lengths else -adapter_length
     )
     search_sets.append(
         (

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -144,11 +144,78 @@ def create_back_overlap_searchsets(
     return search_sets
 
 
-def create_kmers_and_offsets(
+def create_front_overlap_searchsets(
     adapter: str, min_overlap: int, error_rate: float
+) -> List[SearchSet]:
+    adapter_length = len(adapter)
+    error_lengths = []
+    max_error = 1
+    search_sets: List[SearchSet] = []
+    for i in range(adapter_length + 1):
+        if i * error_rate >= max_error:
+            error_lengths.append(i)
+            max_error += 1
+
+    # Add a couple of directly matching 1, 2, 3 and 4-mer searches.
+    # The probability of a false positive is just too high when for example
+    # a 3-mer is evaluated in more than one position.
+    min_overlap_kmer_length = 5
+    if min_overlap < min_overlap_kmer_length:
+        for i in range(min_overlap, min_overlap_kmer_length):
+            search_sets.append(
+                (
+                    0,
+                    i,
+                    [
+                        {
+                            adapter[-i:],
+                        }
+                    ],
+                )
+            )
+        min_overlap = min_overlap_kmer_length
+    # Build up the array with chunks which should occur at the start of the
+    # adapter overlaps with the start
+    min_overlap_kmer = adapter[-min_overlap:]
+    min_overlap_kmer_stop = (
+        error_lengths[0] - 1 if error_lengths else adapter_length - 1
+    )
+    search_sets.append(
+        (
+            0,
+            min_overlap_kmer_stop,
+            [
+                {
+                    min_overlap_kmer,
+                }
+            ],
+        )
+    )
+    for i, error_length in enumerate(error_lengths):
+        if (i + 1) < len(error_lengths):
+            next_length = error_lengths[i + 1]
+        else:
+            next_length = adapter_length
+        stop = next_length - 1
+        number_of_errors = i + 1
+        kmer_sets = kmer_possibilities(adapter[-error_length:], number_of_errors + 1)
+        search_sets.append((0, stop, kmer_sets))
+    return search_sets
+
+
+def create_kmers_and_offsets(
+    adapter: str, error_rate: float, back_overlap: int = 0, front_overlap: int = 0
 ) -> List[Tuple[str, int, Optional[int]]]:
     max_errors = int(len(adapter) * error_rate)
-    search_sets = create_back_overlap_searchsets(adapter, min_overlap, error_rate)
+    search_sets = []
+    if back_overlap:
+        search_sets.extend(
+            create_back_overlap_searchsets(adapter, back_overlap, error_rate)
+        )
+    if front_overlap:
+        search_sets.extend(
+            create_front_overlap_searchsets(adapter, front_overlap, error_rate)
+        )
     kmer_sets = kmer_possibilities(adapter, max_errors + 1)
     search_sets.append((0, None, kmer_sets))
     return find_optimal_kmers(search_sets)

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -102,57 +102,39 @@ def create_back_overlap_searchsets(
 ) -> List[SearchSet]:
     adapter_length = len(adapter)
     error_lengths = []
-    max_error = 1
+    max_error = 0
     search_sets: List[SearchSet] = []
     for i in range(adapter_length + 1):
-        if i * error_rate >= max_error:
-            error_lengths.append(i)
+        if int(i * error_rate) > max_error:
+            error_lengths.append((max_error, i - 1))
             max_error += 1
+    error_lengths.append((max_error, adapter_length))
 
-    # Add a couple of directly matching 1, 2, 3 and 4-mer searches.
-    # The probability of a false positive is just to high when for example
-    # a 3-mer is evaluated in more than one position.
-    min_overlap_kmer_length = 5
-    if min_overlap < min_overlap_kmer_length:
-        for i in range(min_overlap, min_overlap_kmer_length):
-            search_sets.append(
-                (
-                    -i,
-                    None,
-                    [
-                        {
-                            adapter[:i],
-                        }
-                    ],
-                )
-            )
-        min_overlap = min_overlap_kmer_length
-    # Build up the array with chunks which should occur at the tail end
-    # if the adapter overlaps with the end.
-    min_overlap_kmer = adapter[:min_overlap]
-    min_overlap_kmer_start = (
-        -(error_lengths[0] - 1) if error_lengths else -adapter_length
-    )
-    search_sets.append(
-        (
-            min_overlap_kmer_start,
-            None,
-            [
-                {
-                    min_overlap_kmer,
-                }
-            ],
-        )
-    )
-    for i, error_length in enumerate(error_lengths):
-        if (i + 1) < len(error_lengths):
-            check_length = error_lengths[i + 1] - 1
+    previous_length = min_overlap
+    for max_errors, length in error_lengths:
+        if min_overlap > length:
+            continue
+        if max_errors == 0:
+            # 0 Is a special case as we only have to match min_overlap
+            # characters in the largest overlap without errors
+            # Add a couple of directly matching 1, 2, 3 and 4-mer searches.
+            # The probability of a false positive is just to high when for
+            # example a 3-mer is evaluated in more than one position.
+            min_overlap_kmer_length = 5
+            if min_overlap < min_overlap_kmer_length:
+                for i in range(min_overlap, min_overlap_kmer_length):
+                    search_set = (-i, None, [{adapter[:i]}])
+                    search_sets.append(search_set)
+                min_overlap = min_overlap_kmer_length
+            min_overlap_kmer = adapter[:min_overlap]
+            search_set = (-(length - 1), None, [{min_overlap_kmer}])
+            search_sets.append(search_set)
         else:
-            check_length = adapter_length
-        start = -check_length
-        number_of_errors = i + 1
-        kmer_sets = kmer_possibilities(adapter[:error_length], number_of_errors + 1)
-        search_sets.append((start, None, kmer_sets))
+            start = -(length)
+            minimum_length = previous_length + 1
+            kmer_sets = kmer_possibilities(adapter[:minimum_length], max_errors + 1)
+            search_sets.append((start, None, kmer_sets))
+        previous_length = length
     return search_sets
 
 

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -182,6 +182,15 @@ def kmer_probability_analysis(
     kmers_and_offsets: List[Tuple[int, Optional[int], List[str]]],
     default_length: int = 150,
 ) -> str:  # pragma: no cover  # only for debugging use
+    """
+    Returns a tab separated table with for each kmer a start, stop, the number
+    of considered sites and the hit chance on a randomly generated sequence
+    containing only A, C, G and T. Assumes kmers only consist of A, C, G and T
+    too.
+
+    Useful for investigating whether the create_positions_and_kmers function
+    creates a useful runtime heuristic.
+    """
     out = io.StringIO()
     out.write(
         "kmer\tstart\tstop\tconsidered sites\thit chance by random sequence (%)\n"

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -67,7 +67,7 @@ def minimize_kmer_search_list(
                 "Situations with searches starting in the middle have not been considered."
             )
         if front_searches:
-            # (0, None) condition is already catched, so stop is never None.
+            # (0, None) condition is already caught, so stop is never None.
             kmers_and_positions.append(
                 (kmer, 0, max(stop for start, stop in front_searches))  # type: ignore
             )

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -110,31 +110,23 @@ def create_back_overlap_searchsets(
             max_error += 1
     error_lengths.append((max_error, adapter_length))
 
-    previous_length = min_overlap
+    minimum_length = min_overlap
     for max_errors, length in error_lengths:
-        if min_overlap > length:
+        if minimum_length > length:
             continue
         if max_errors == 0:
-            # 0 Is a special case as we only have to match min_overlap
-            # characters in the largest overlap without errors
             # Add a couple of directly matching 1, 2, 3 and 4-mer searches.
             # The probability of a false positive is just to high when for
             # example a 3-mer is evaluated in more than one position.
             min_overlap_kmer_length = 5
-            if min_overlap < min_overlap_kmer_length:
-                for i in range(min_overlap, min_overlap_kmer_length):
+            if minimum_length < min_overlap_kmer_length:
+                for i in range(minimum_length, min_overlap_kmer_length):
                     search_set = (-i, None, [{adapter[:i]}])
                     search_sets.append(search_set)
-                min_overlap = min_overlap_kmer_length
-            min_overlap_kmer = adapter[:min_overlap]
-            search_set = (-length, None, [{min_overlap_kmer}])
-            search_sets.append(search_set)
-        else:
-            start = -length
-            minimum_length = previous_length + 1
-            kmer_sets = kmer_possibilities(adapter[:minimum_length], max_errors + 1)
-            search_sets.append((start, None, kmer_sets))
-        previous_length = length
+                minimum_length = min_overlap_kmer_length
+        kmer_sets = kmer_possibilities(adapter[:minimum_length], max_errors + 1)
+        search_sets.append((-length, None, kmer_sets))
+        minimum_length = length + 1
     return search_sets
 
 

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -195,7 +195,9 @@ def kmer_probability_analysis(
     kmers_and_offsets: List[Tuple[str, int, Optional[int]]], default_length: int = 150
 ) -> str:
     out = io.StringIO()
-    out.write("kmer\tstart\tstop\tconsidered sites\thit chance by random sequence (%)\n")
+    out.write(
+        "kmer\tstart\tstop\tconsidered sites\thit chance by random sequence (%)\n"
+    )
     accumulated_not_hit_chance = 1.0
     for kmer, start, stop in kmers_and_offsets:
         kmer_length = len(kmer)

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -127,10 +127,10 @@ def create_back_overlap_searchsets(
                     search_sets.append(search_set)
                 min_overlap = min_overlap_kmer_length
             min_overlap_kmer = adapter[:min_overlap]
-            search_set = (-(length - 1), None, [{min_overlap_kmer}])
+            search_set = (-length, None, [{min_overlap_kmer}])
             search_sets.append(search_set)
         else:
-            start = -(length)
+            start = -length
             minimum_length = previous_length + 1
             kmer_sets = kmer_possibilities(adapter[:minimum_length], max_errors + 1)
             search_sets.append((start, None, kmer_sets))

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -9,8 +9,8 @@ def kmer_possibilities(sequence: str, chunks: int) -> List[Set[str]]:
     """
     Partition a sequence in almost equal sized chunks. Return all possibilities.
 
-    >>> kmer_possibilities("ABCDEFGH", 3)
-    [{"ABC", "DEF", "GH"}, {"ABC", "DE", "FGH"}, {"AB", "CDE", "FGH"}]
+    Example sequence ABCDEFGH with 3 chunks. Possibilities:
+    ["ABC", "DEF", "GH"]; ["ABC", "DE", "FGH"]; ["AB", "CDE", "FGH"]
     """
     chunk_size = len(sequence) // (chunks)
     remainder = len(sequence) % (chunks)

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -146,10 +146,10 @@ def create_back_overlap_searchsets(
     )
     for i, error_length in enumerate(error_lengths):
         if (i + 1) < len(error_lengths):
-            next_length = error_lengths[i + 1]
+            check_length = error_lengths[i + 1] - 1
         else:
-            next_length = adapter_length
-        start = -(next_length - 1)
+            check_length = adapter_length
+        start = -check_length
         number_of_errors = i + 1
         kmer_sets = kmer_possibilities(adapter[:error_length], number_of_errors + 1)
         search_sets.append((start, None, kmer_sets))

--- a/tests/test_kmer_finder.py
+++ b/tests/test_kmer_finder.py
@@ -55,9 +55,9 @@ def test_kmer_finder(
     ["ref_table", "query_table", "comp_op", "ref_wildcards", "query_wildcards"],
     [
         (UPPER_TABLE, UPPER_TABLE, operator.eq, False, False),
-        (IUPAC_TABLE, ACGT_TABLE, operator.or_, True, False),
-        (ACGT_TABLE, IUPAC_TABLE, operator.or_, False, True),
-        (IUPAC_TABLE, IUPAC_TABLE, operator.or_, True, True),
+        (IUPAC_TABLE, ACGT_TABLE, operator.and_, True, False),
+        (ACGT_TABLE, IUPAC_TABLE, operator.and_, False, True),
+        (IUPAC_TABLE, IUPAC_TABLE, operator.and_, True, True),
     ],
 )
 def test_kmer_finder_per_char_matching(
@@ -72,7 +72,9 @@ def test_kmer_finder_per_char_matching(
             ref_wildcards=ref_wildcards,
             query_wildcards=query_wildcards,
         )
+        ref_char = ref_table[ord(char)]
         for comp_char in iupac_letters:
-            should_match = comp_op(ref_table[ord(char)], query_table[ord(comp_char)])
+            query_char = query_table[ord(comp_char)]
+            should_match = bool(comp_op(ref_char, query_char))
             if kmer_finder.kmers_present(comp_char) is not should_match:
-                raise ValueError(f"{char} should match {comp_char}")
+                raise ValueError(f"{char} should{' ' if should_match else ' not '}match {comp_char}")

--- a/tests/test_kmer_finder.py
+++ b/tests/test_kmer_finder.py
@@ -107,7 +107,7 @@ def test_kmer_finder_finds_all():
         "previously thought."
     )
     assert not kmer_finder.kmers_present(
-        "A turtle maybe slow, but it also lives for a long time."
+        "A turtle may be slow, but it also lives for a long time."
     )
 
 
@@ -117,5 +117,5 @@ def test_kmer_finder_finds_in_region():
     assert kmer_finder.kmers_present("Each one has to find his peace from within")
     # Peace not found here because outside of the search range.
     assert not kmer_finder.kmers_present(
-        "And peace to be real must be unaffected " "by outside circumstances."
+        "And peace to be real must be unaffected by outside circumstances."
     )

--- a/tests/test_kmer_finder.py
+++ b/tests/test_kmer_finder.py
@@ -1,4 +1,5 @@
 import operator
+import string
 
 import pytest
 
@@ -63,18 +64,17 @@ def test_kmer_finder(
 def test_kmer_finder_per_char_matching(
     ref_table, query_table, comp_op, ref_wildcards, query_wildcards
 ):
-    iupac_letters = "ACGTURYSWKMBDHVN"
-    iupac_letters = iupac_letters + iupac_letters.lower()
-
-    for char in iupac_letters:
+    for char in string.ascii_letters:
         kmer_finder = KmerFinder(
             [(char, 0, None)],
             ref_wildcards=ref_wildcards,
             query_wildcards=query_wildcards,
         )
         ref_char = ref_table[ord(char)]
-        for comp_char in iupac_letters:
+        for comp_char in string.ascii_letters:
             query_char = query_table[ord(comp_char)]
             should_match = bool(comp_op(ref_char, query_char))
             if kmer_finder.kmers_present(comp_char) is not should_match:
-                raise ValueError(f"{char} should{' ' if should_match else ' not '}match {comp_char}")
+                raise ValueError(
+                    f"{char} should{' ' if should_match else ' not '}match {comp_char}"
+                )

--- a/tests/test_kmer_finder.py
+++ b/tests/test_kmer_finder.py
@@ -48,7 +48,7 @@ def test_kmer_finder(
     sequence: str,
     expected: bool,
 ):
-    kmer_finder = KmerFinder([(kmer, start, stop)], ref_wildcards, query_wildcards)
+    kmer_finder = KmerFinder([(start, stop, [kmer])], ref_wildcards, query_wildcards)
     assert kmer_finder.kmers_present(sequence) is expected
 
 
@@ -66,7 +66,7 @@ def test_kmer_finder_per_char_matching(
 ):
     for char in string.ascii_letters:
         kmer_finder = KmerFinder(
-            [(char, 0, None)],
+            [(0, None, [char])],
             ref_wildcards=ref_wildcards,
             query_wildcards=query_wildcards,
         )
@@ -78,3 +78,44 @@ def test_kmer_finder_per_char_matching(
                 raise ValueError(
                     f"{char} should{' ' if should_match else ' not '}match {comp_char}"
                 )
+
+
+def test_kmer_finder_initialize_bigword():
+    with pytest.raises(ValueError) as error:
+        KmerFinder([(0, None, ["A" * 64])])
+    error.match("A" * 64)
+    error.match("64")
+
+
+def test_kmer_finder_initialize_total_greater_than_max():
+    kmer_finder = KmerFinder([(0, None, ["A" * 31, "B" * 31, "C" * 31, "D" * 43])])
+    assert kmer_finder.kmers_present("X" * 100 + "A" * 31)
+    assert kmer_finder.kmers_present("X" * 100 + "B" * 31)
+    assert kmer_finder.kmers_present("X" * 100 + "C" * 31)
+    assert kmer_finder.kmers_present("X" * 100 + "D" * 43)
+    assert not kmer_finder.kmers_present(string.ascii_letters)
+
+
+def test_kmer_finder_finds_all():
+    kmer_finder = KmerFinder([(0, None, ["teenage", "mutant", "ninja", "turtles"])])
+    assert kmer_finder.kmers_present("Smells like teenage spirit")
+    assert kmer_finder.kmers_present("Everyone with a SNP is technically a mutant.")
+    assert kmer_finder.kmers_present("He made a ninja PR that was merged before review")
+    assert kmer_finder.kmers_present(
+        "Turtles are treated as outgroup, for 'more advanced' reptiles but "
+        "molecular evidence suggests they are more close to the dinosaurs than "
+        "previously thought."
+    )
+    assert not kmer_finder.kmers_present(
+        "A turtle maybe slow, but it also lives for a long time."
+    )
+
+
+def test_kmer_finder_finds_in_region():
+    kmer_finder = KmerFinder([(-20, None, ["peace"])])
+    # Finding peace, quotes from Mahatma Gandhi
+    assert kmer_finder.kmers_present("Each one has to find his peace from within")
+    # Peace not found here because outside of the search range.
+    assert not kmer_finder.kmers_present(
+        "And peace to be real must be unaffected " "by outside circumstances."
+    )

--- a/tests/test_kmer_finder.py
+++ b/tests/test_kmer_finder.py
@@ -1,0 +1,45 @@
+import pytest
+
+from cutadapt.adapters import KmerFinder
+
+
+KMER_FINDER_TESTS = [
+    # kmer, start, stop, ref_wildcards, query_wildcards, sequence, expected
+    ("ACGT", 0, None, False, False, "ACGTACG", True),
+    ("ACGT", 0, None, False, False, "ACgtACG", True),
+    ("acgt", 0, None, False, False, "ACgtACG", True),
+    ("ACGT", 0, None, False, False, "acgtacg", True),
+    ("ACGT", 0, None, False, False, "gacgact", False),
+    ("ACGT", 0, None, False, True, "ACGNACG", True),
+    ("ACGT", 0, None, False, False, "ACGNACG", False),
+    ("ACGN", 0, None, True, False, "ACGTACG", True),
+    ("ACGN", 0, None, True, False, "ACGxACG", True),
+    ("ACKN", 0, None, True, False, "ACGTACG", True),
+    ("ACKN", 0, None, True, True, "ACWRACG", True),
+    ("ACKN", 0, None, True, True, "ACWxACG", False),
+]
+
+
+@pytest.mark.parametrize(
+    [
+        "kmer",
+        "start",
+        "stop",
+        "ref_wildcards",
+        "query_wildcards",
+        "sequence",
+        "expected",
+    ],
+    KMER_FINDER_TESTS,
+)
+def test_kmer_finder(
+    kmer: str,
+    start: int,
+    stop: int,
+    ref_wildcards: bool,
+    query_wildcards: bool,
+    sequence: str,
+    expected: bool,
+):
+    kmer_finder = KmerFinder([(kmer, start, stop)], ref_wildcards, query_wildcards)
+    assert kmer_finder.kmers_present(sequence) is expected

--- a/tests/test_kmer_heuristic.py
+++ b/tests/test_kmer_heuristic.py
@@ -1,0 +1,51 @@
+import pytest
+
+from cutadapt.kmer_heuristic import (
+    kmer_possibilities,
+    minimize_kmer_search_list,
+    create_back_overlap_searchsets,
+)
+
+
+@pytest.mark.parametrize(
+    ["sequence", "chunks", "expected"],
+    [
+        ("ABC", 3, [{"A", "B", "C"}]),
+        ("ABCD", 3, [{"A", "B", "CD"}, {"A", "BC", "D"}, {"AB", "C", "D"}]),
+    ],
+)
+def test_kmer_possibilities(sequence, chunks, expected):
+    frozen_expected = set(frozenset(s) for s in expected)
+    result = kmer_possibilities(sequence, chunks)
+    frozen_result = set(frozenset(s) for s in result)
+    assert frozen_expected == frozen_result
+
+
+@pytest.mark.parametrize(
+    ["kmer_search_list", "expected"],
+    [
+        ([("ABC", -33, None), ("ABC", -19, None)], [("ABC", -33, None)]),
+        (
+            [("ABC", -33, None), ("ABC", -19, None), ("ABC", 0, None)],
+            [("ABC", 0, None)],
+        ),
+        ([("ABC", 0, 10), ("ABC", 0, 20)], [("ABC", 0, 20)]),
+        ([("ABC", 0, 10), ("ABC", 0, 20), ("ABC", 0, None)], [("ABC", 0, None)]),
+        ([("ABC", 0, 10), ("ABC", -19, None), ("ABC", 0, None)], [("ABC", 0, None)]),
+        ([("ABC", 0, 10), ("ABC", -19, None)], [("ABC", 0, 10), ("ABC", -19, None)]),
+    ],
+)
+def test_minimize_kmer_search_list(kmer_search_list, expected):
+    result = minimize_kmer_search_list(kmer_search_list)
+    assert set(result) == set(expected)
+
+
+def test_create_back_overlap_searchsets():
+    adapter = "ABCDEFGHIJ0123456789"
+    searchsets = create_back_overlap_searchsets(adapter, 3, 0.1)
+    assert len(searchsets) == 5
+    assert (-3, None, [{"ABC"}]) in searchsets
+    assert (-4, None, [{"ABCD"}]) in searchsets
+    assert (-9, None, [{"ABCDE"}]) in searchsets
+    assert (-19, None, kmer_possibilities(adapter[:10], 2)) in searchsets
+    assert (-20, None, kmer_possibilities(adapter, 3)) in searchsets

--- a/tests/test_kmer_heuristic.py
+++ b/tests/test_kmer_heuristic.py
@@ -56,7 +56,7 @@ def test_create_back_overlap_searchsets():
     ["kwargs", "expected"],
     [
         (
-            dict(back_adapter=True, front_adapter=False, internal=True),
+            dict(back_adapter=True, front_adapter=False, internal=True, min_overlap=3),
             [
                 ("ABC", -3, None),
                 ("ABCD", -4, None),
@@ -68,7 +68,7 @@ def test_create_back_overlap_searchsets():
             ],
         ),
         (
-            dict(back_adapter=True, front_adapter=False, internal=False),
+            dict(back_adapter=True, front_adapter=False, internal=False, min_overlap=3),
             [
                 ("ABC", -3, None),
                 ("ABCD", -4, None),
@@ -80,7 +80,7 @@ def test_create_back_overlap_searchsets():
             ],
         ),
         (
-            dict(back_adapter=False, front_adapter=True, internal=False),
+            dict(back_adapter=False, front_adapter=True, internal=False, min_overlap=3),
             [
                 ("789", 0, 3),
                 ("6789", 0, 4),
@@ -92,7 +92,15 @@ def test_create_back_overlap_searchsets():
             ],
         ),
         (
-            dict(back_adapter=False, front_adapter=False, internal=True),
+            dict(back_adapter=True, front_adapter=False, internal=True, min_overlap=20),
+            [
+                ("ABCDEFG", 0, None),
+                ("HIJ0123", 0, None),
+                ("456789", 0, None),
+            ],
+        ),
+        (
+            dict(back_adapter=False, front_adapter=False, internal=True, min_overlap=3),
             [
                 ("ABCDEFG", 0, None),
                 ("HIJ0123", 0, None),
@@ -106,7 +114,6 @@ def test_create_kmers_and_positions(kwargs, expected):
     result = create_kmers_and_positions(
         adapter,
         error_rate=0.1,
-        min_overlap=3,
         **kwargs,
     )
     assert set(result) == set(expected)

--- a/tests/test_kmer_heuristic.py
+++ b/tests/test_kmer_heuristic.py
@@ -4,7 +4,7 @@ from cutadapt.kmer_heuristic import (
     kmer_possibilities,
     minimize_kmer_search_list,
     create_back_overlap_searchsets,
-    create_kmers_and_positions,
+    create_positions_and_kmers,
 )
 
 
@@ -58,62 +58,51 @@ def test_create_back_overlap_searchsets():
         (
             dict(back_adapter=True, front_adapter=False, internal=True, min_overlap=3),
             [
-                ("ABC", -3, None),
-                ("ABCD", -4, None),
-                ("ABCDE", -19, None),
-                ("FGHIJ", -19, None),
-                ("ABCDEFG", 0, None),
-                ("HIJ0123", 0, None),
-                ("456789", 0, None),
+                (-3, None, ["ABC"]),
+                (-4, None, ["ABCD"]),
+                (-19, None, ["ABCDE", "FGHIJ"]),
+                (0, None, ["ABCDEFG", "HIJ0123", "456789"]),
             ],
         ),
         (
             dict(back_adapter=True, front_adapter=False, internal=False, min_overlap=3),
             [
-                ("ABC", -3, None),
-                ("ABCD", -4, None),
-                ("ABCDE", -19, None),
-                ("FGHIJ", -19, None),
-                ("ABCDEFG", -20, None),
-                ("HIJ0123", -20, None),
-                ("456789", -20, None),
+                (-3, None, ["ABC"]),
+                (-4, None, ["ABCD"]),
+                (-19, None, ["ABCDE", "FGHIJ"]),
+                (-20, None, ["ABCDEFG", "HIJ0123", "456789"]),
             ],
         ),
         (
             dict(back_adapter=False, front_adapter=True, internal=False, min_overlap=3),
             [
-                ("789", 0, 3),
-                ("6789", 0, 4),
-                ("56789", 0, 19),
-                ("01234", 0, 19),
-                ("ABCDEF", 0, 20),
-                ("GHIJ012", 0, 20),
-                ("3456789", 0, 20),
+                (0, 3, ["789"]),
+                (0, 4, ["6789"]),
+                (0, 19, ["01234", "56789"]),
+                (0, 20, ["ABCDEF", "GHIJ012", "3456789"]),
             ],
         ),
         (
             dict(back_adapter=True, front_adapter=False, internal=True, min_overlap=20),
             [
-                ("ABCDEFG", 0, None),
-                ("HIJ0123", 0, None),
-                ("456789", 0, None),
+                (0, None, ["ABCDEFG", "HIJ0123", "456789"]),
             ],
         ),
         (
             dict(back_adapter=False, front_adapter=False, internal=True, min_overlap=3),
             [
-                ("ABCDEFG", 0, None),
-                ("HIJ0123", 0, None),
-                ("456789", 0, None),
+                (0, None, ["ABCDEFG", "HIJ0123", "456789"]),
             ],
         ),
     ],
 )
 def test_create_kmers_and_positions(kwargs, expected):
     adapter = "ABCDEFGHIJ0123456789"
-    result = create_kmers_and_positions(
+    result = create_positions_and_kmers(
         adapter,
         error_rate=0.1,
         **kwargs,
     )
-    assert set(result) == set(expected)
+    assert {(start, stop): frozenset(kmers) for start, stop, kmers in result} == {
+        (start, stop): frozenset(kmers) for start, stop, kmers in expected
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ install_command = python -m pip install --only-binary :all: {opts} {packages}
 setenv = PYTHONDEVMODE = 1
 commands =
     coverage run -m pytest --doctest-modules --pyargs cutadapt tests
-    coverage combine -q
     coverage report
     coverage xml
 
@@ -40,8 +39,6 @@ commands = black --check src/ tests/ setup.py
 
 [coverage:run]
 branch = True
-parallel = True
-concurrency = multiprocessing
 source_pkgs = cutadapt
 source = tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ install_command = python -m pip install --only-binary :all: {opts} {packages}
 setenv = PYTHONDEVMODE = 1
 commands =
     coverage run -m pytest --doctest-modules --pyargs cutadapt tests
+    coverage combine -q
     coverage report
     coverage xml
 
@@ -39,6 +40,8 @@ commands = black --check src/ tests/ setup.py
 
 [coverage:run]
 branch = True
+parallel = True
+concurrency = multiprocessing
 source_pkgs = cutadapt
 source = tests
 


### PR DESCRIPTION
Alignment is the most cost effective way for approximately matching an adapter to a read sequence at the best possible position. The cost of this is alignment is proportional to the size of the adapter (m) multiplied by the length of the sequence (n). O(mn) cost means that the alignment is the most costly part of cutadapt.

There is however a subproblem that is much easier to solve: determining if an adapter is at all present in a sequence. If x errors are allowed, we can subdivide the adapter in x+1 pieces. It follows that at least one of the pieces must be present in the sequence without error. Modern search algorithms operate at a speed of near O(n) even for multiple pattern matching. When a sequence is determined not to be present in a read, alignment can be skipped. This results in a much reduced time to completion.

This PR adds a kmer_heuristic.py file which provides an algorithm for cutting up the adapter in pieces at least one of which must occur. It has code to handle adapters that only partially overlap at the beginning of the end and can handle internal and non-internal adapters.

It also provides the shift-OR string searching algorithm. This algorithm uses a lookup table of bitmasks to determine if a word matches. The bitmasks can be created at the program initialization rather than at string searching time giving this algorithm an advantage over generic string searching functions such as CPython's find method or C stdlib's strstr. This means the seach algorithm runs at O(n) rather than O(m+n) since the initialization cost is not payed for each read. Another advantage of shift-OR algorithm is that matching IUPAC costs the same as direct matching. The KmerFinder class created in its own Cython file handles the creation and storage of the bitmasks, as well as the searching. The shift-OR algorithm was slightly altered to store multiple words in each bit matrix so all words can be foud in O(n) time while performing multiple pattern matching.

Preliminary benchmarks show that the heuristic runs 20 times faster than the alignment. This means that theoretically the cost of the heuristic is worth it unless the adapter content is above 95%. Since the heuristic exits early when one of the sequences is found, the tipping point might actually be higher than 95. 

EDIT: Updated to reflect PR content. This makes for a better merge commit message. Original message below.
EDIT2: Further updates including the O(n) nature of the updated algorithm.

<details><summary>Original message</summary>

Hi, just a draft PR to investigate this new possibility I informed you about. 
cProfile result before:
```
  5000000    1.486    0.000   24.305    0.000 adapters.py:749(match_to)
  5000000   22.613    0.000   22.613    0.000 {method 'locate' of 'cutadapt._align.Aligner' objects}
   559384    0.390    0.000    0.667    0.000 adapters.py:177(add_match)
```

After:
```
  5000000    1.413    0.000   11.415    0.000 adapters.py:761(match_to)
  5000000    5.639    0.000    5.639    0.000 {method 'kmers_present' of 'cutadapt._kmer_finder.KmerFinder' objects}
   797111    4.157    0.000    4.157    0.000 {method 'locate' of 'cutadapt._align.Aligner' objects}
   559384    0.380    0.000    0.655    0.000 adapters.py:179(add_match)
```
As you can see, the heuristic is not cheap it roughly requires 25% of the alignment resources. It is quite effective though in eliminating reads that cannot possibly have an adapter. 

In terms of performance on my PC the main cutadapt processes 9.4M reads per minute and with this addition reaches 16.1M reads per minute.

This still needs tests and a way to shut off the heuristic when it becomes to costly. But at least it is in a good enough state to play around with the parameters a bit and see how this can be integrated best.

</details>
