### PR TITLE
Utilize full length of the 64-bit word in the KmerFinder

### DIFF
--- a/src/cutadapt/_kmer_finder.pyi
+++ b/src/cutadapt/_kmer_finder.pyi
@@ -1,5 +1,7 @@
 from typing import List, Optional, Tuple
 
+MAXIMUM_WORD_SIZE: int
+
 class KmerFinder:
     def __init__(
         self,

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -245,14 +245,13 @@ cdef bint shift_and_multiple_is_present(
     bitmask_t init_mask,
     bitmask_t found_mask):
     cdef:
-        bitmask_t R = init_mask
+        bitmask_t R = 0
         size_t i
 
     for i in range(haystack_length):
-        # Update the bit array
+        R <<= 1
+        R |= init_mask
         R &= needle_mask[<uint8_t>haystack[i]]
         if (R & found_mask):
             return True
-        R <<= 1
-        R |= init_mask
     return False

--- a/src/cutadapt/_kmer_finder.pyx
+++ b/src/cutadapt/_kmer_finder.pyx
@@ -21,7 +21,7 @@ four-letter alphabet we can make the following bitmatrix for the word ACGTA
 0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_00001000  T
 
 However, this leaves a lot of bits unused in the machine word. It is also
-possible to use as many bits in a bitmask as possible simply concatening
+possible to use as many bits in a bitmask as possible simply concatenating
 all the words together. For example here, with appended GATTACA.
 
                                                             ACAT_TAGATGCA
@@ -48,7 +48,7 @@ DEF BITMASK_INDEX_SIZE = 128
 
 ctypedef size_t bitmask_t
 
-DEF MAX_WORD_SIZE = 64  # sizeof does not work for some reason
+DEF MAX_WORD_SIZE = 64  # "sizeof(bitmask_t) * 8" does not work for some reason
 MAXIMUM_WORD_SIZE = MAX_WORD_SIZE
 
 cdef extern from "Python.h":

--- a/tests/test_kmer_finder.py
+++ b/tests/test_kmer_finder.py
@@ -4,6 +4,8 @@ import pytest
 
 from cutadapt._match_tables import matches_lookup
 from cutadapt.adapters import KmerFinder
+from cutadapt._kmer_finder import MAXIMUM_WORD_SIZE
+
 
 KMER_FINDER_TESTS = [
     # kmer, start, stop, ref_wildcards, query_wildcards, sequence, expected
@@ -76,16 +78,16 @@ def test_kmer_finder_per_char_matching(ref_wildcards, query_wildcards):
 
 def test_kmer_finder_initialize_bigword():
     with pytest.raises(ValueError) as error:
-        KmerFinder([(0, None, ["A" * 64])])
-    error.match("A" * 64)
-    error.match("64")
+        KmerFinder([(0, None, ["A" * (MAXIMUM_WORD_SIZE + 1)])])
+    error.match("A" * (MAXIMUM_WORD_SIZE + 1))
+    error.match(str(MAXIMUM_WORD_SIZE))
 
 
 def test_kmer_finder_initialize_total_greater_than_max():
-    kmer_finder = KmerFinder([(0, None, ["A" * 31, "B" * 31, "C" * 31, "D" * 43])])
-    assert kmer_finder.kmers_present("X" * 100 + "A" * 31)
-    assert kmer_finder.kmers_present("X" * 100 + "B" * 31)
-    assert kmer_finder.kmers_present("X" * 100 + "C" * 31)
+    kmer_finder = KmerFinder([(0, None, ["A" * 32, "B" * 32, "C" * 32, "D" * 43])])
+    assert kmer_finder.kmers_present("X" * 100 + "A" * 32)
+    assert kmer_finder.kmers_present("X" * 100 + "B" * 32)
+    assert kmer_finder.kmers_present("X" * 100 + "C" * 32)
     assert kmer_finder.kmers_present("X" * 100 + "D" * 43)
     assert not kmer_finder.kmers_present(string.ascii_letters)
 


### PR DESCRIPTION
Thanks again for replying to my e-mail. 
This PR holds the following changes:
- In the bitmatrix the empty columns have been made redundant by a slight reorganization of the search algorithm. Directly after the mask is applied, the check for a match is run, rather than after the shift operation. This holds the advantage that an adapter of 64 can always be fit in one word, regardless of how many individual pieces are needed due to the error rate.
- The value of 64 is hardcoded in one place and made available as a variable. This is used in tests.
- The SHIFT-OR algorithm was changed to SHIFT-AND for the following reasons:
    + SHIFT-OR does not have an advantage over SHIFT-AND. The zeroes that are shifted an are of no value as there are multiple words in one machine word and  there needs to be a mask anyway to set the correct bits.
    + SHIFT-AND allows for a simpler check if the word is found. (A simple bitwise AND and non-zero check).
    + SHIFT-AND is easier to understand, SHIFT-OR is just a clever implementation detail which only works for one word per machine word.
    + I also have SHIFT-AND in this other program I work on ([sequali](https://github.com/rhpvorderman/sequali)) and some insights might be transferred in the future when applicable.

I benchmarked the change and it seems to be consistently (very slightly) faster on my laptop (while on battery, not the best platform, I know), which I contribute to the simpler check inside the loop. At least it is certainly not slower.