### PR TITLE
Fix exponential runtime for longer adapters

### DIFF
--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     )
     kmer_finder = KmerFinder(kmers_and_offsets)
     print(kmer_probability_analysis(kmers_and_offsets))
-    with (dnaio.open(args.fastq, mode="r", open_threads=0) as reader,):
+    with dnaio.open(args.fastq, mode="r", open_threads=0) as reader:
         number_of_records = 0
         possible_adapters_found = 0
         for number_of_records, record in enumerate(reader, start=1):

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -219,7 +219,7 @@ if __name__ == "__main__":
     )
     kmer_finder = KmerFinder(kmers_and_offsets)
     print(kmer_probability_analysis(kmers_and_offsets))
-    with dnaio.open(args.fastq, mode="r", open_threads=0) as reader:
+    with dnaio.open(args.fastq, mode="r", open_threads=0) as reader:  # type: ignore
         number_of_records = 0
         possible_adapters_found = 0
         for number_of_records, record in enumerate(reader, start=1):

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -73,9 +73,14 @@ def minimize_kmer_search_list(
     return kmers_and_positions
 
 
-def find_optimal_kmers(
+def remove_redundant_kmers(
     search_sets: List[SearchSet],
 ) -> List[Tuple[int, Optional[int], List[str]]]:
+    """
+    This removes kmers that are searched in multiple search sets and makes
+    sure they are only searched in the larger search set. This reduces the
+    amount of searched patterns and therefore the number of false positives.
+    """
 
     kmer_search_list = []
     for start, stop, kmer_set in search_sets:
@@ -165,7 +170,7 @@ def create_positions_and_kmers(
     if internal:
         kmer_sets = kmer_chunks(adapter, max_errors + 1)
         search_sets.append((0, None, kmer_sets))
-    return find_optimal_kmers(search_sets)
+    return remove_redundant_kmers(search_sets)
 
 
 def kmer_probability_analysis(

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -1,6 +1,4 @@
 import io
-import itertools
-import sys
 from typing import List, Optional, Set, Tuple
 from collections import defaultdict
 

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -226,5 +226,6 @@ if __name__ == "__main__":
             if kmer_finder.kmers_present(record.sequence):
                 possible_adapters_found += 1
     print(
-        f"Percentage possible adapters: {possible_adapters_found / number_of_records}"
+        f"Percentage possible adapters: "
+        f"{possible_adapters_found * 100 / number_of_records:.2f}%"
     )

--- a/src/cutadapt/kmer_heuristic.py
+++ b/src/cutadapt/kmer_heuristic.py
@@ -15,19 +15,12 @@ def kmer_chunks(sequence: str, chunks: int) -> Set[str]:
     chunk_sizes: List[int] = remainder * [chunk_size + 1] + (chunks - remainder) * [
         chunk_size
     ]
-    possible_orderings = set(itertools.permutations(chunk_sizes))
-    kmer_sets = []
-    for chunk_list in possible_orderings:
-        offset = 0
-        chunk_set = set()
-        for size in chunk_list:
-            chunk_set.add(sequence[offset : offset + size])
-            offset += size
-        kmer_sets.append(chunk_set)
-    sorted_by_length = sorted((len(chunk_set), chunk_set) for chunk_set in kmer_sets)
-    # Sometimes there are repeated sequences which make a set shorter
-    shortest_length, shortest_set = sorted_by_length[0]
-    return shortest_set
+    offset = 0
+    chunk_set = set()
+    for size in chunk_sizes:
+        chunk_set.add(sequence[offset : offset + size])
+        offset += size
+    return chunk_set
 
 
 # A SearchSet is a start and stop combined with a set of strings to search

--- a/tests/test_kmer_heuristic.py
+++ b/tests/test_kmer_heuristic.py
@@ -108,7 +108,9 @@ def test_create_kmers_and_positions(kwargs, expected):
 @pytest.mark.timeout(0.5)
 def test_create_positions_and_kmers_slow():
     create_positions_and_kmers(
-        "A" * 100,
+        # Ridiculous size to check if there aren't any quadratic or exponential
+        # algorithms in the code.
+        "A" * 1000,
         min_overlap=3,
         error_rate=0.1,
         back_adapter=True,

--- a/tests/test_kmer_heuristic.py
+++ b/tests/test_kmer_heuristic.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cutadapt.kmer_heuristic import (
-    kmer_possibilities,
+    kmer_chunks,
     minimize_kmer_search_list,
     create_back_overlap_searchsets,
     create_positions_and_kmers,
@@ -11,15 +11,12 @@ from cutadapt.kmer_heuristic import (
 @pytest.mark.parametrize(
     ["sequence", "chunks", "expected"],
     [
-        ("ABC", 3, [{"A", "B", "C"}]),
-        ("ABCD", 3, [{"A", "B", "CD"}, {"A", "BC", "D"}, {"AB", "C", "D"}]),
+        ("ABC", 3, {"A", "B", "C"}),
+        ("ABCD", 3, {"AB", "C", "D"}),
     ],
 )
-def test_kmer_possibilities(sequence, chunks, expected):
-    frozen_expected = set(frozenset(s) for s in expected)
-    result = kmer_possibilities(sequence, chunks)
-    frozen_result = set(frozenset(s) for s in result)
-    assert frozen_expected == frozen_result
+def test_kmer_chunks(sequence, chunks, expected):
+    assert kmer_chunks(sequence, chunks) == expected
 
 
 @pytest.mark.parametrize(
@@ -106,3 +103,15 @@ def test_create_kmers_and_positions(kwargs, expected):
     assert {(start, stop): frozenset(kmers) for start, stop, kmers in result} == {
         (start, stop): frozenset(kmers) for start, stop, kmers in expected
     }
+
+
+@pytest.mark.timeout(0.5)
+def test_create_positions_and_kmers_slow():
+    create_positions_and_kmers(
+        "A" * 100,
+        min_overlap=3,
+        error_rate=0.1,
+        back_adapter=True,
+        front_adapter=False,
+        internal=True,
+    )

--- a/tests/test_kmer_heuristic.py
+++ b/tests/test_kmer_heuristic.py
@@ -42,11 +42,11 @@ def test_create_back_overlap_searchsets():
     adapter = "ABCDEFGHIJ0123456789"
     searchsets = create_back_overlap_searchsets(adapter, 3, 0.1)
     assert len(searchsets) == 5
-    assert (-3, None, [{"ABC"}]) in searchsets
-    assert (-4, None, [{"ABCD"}]) in searchsets
-    assert (-9, None, [{"ABCDE"}]) in searchsets
-    assert (-19, None, kmer_possibilities(adapter[:10], 2)) in searchsets
-    assert (-20, None, kmer_possibilities(adapter, 3)) in searchsets
+    assert (-3, None, {"ABC"}) in searchsets
+    assert (-4, None, {"ABCD"}) in searchsets
+    assert (-9, None, {"ABCDE"}) in searchsets
+    assert (-19, None, kmer_chunks(adapter[:10], 2)) in searchsets
+    assert (-20, None, kmer_chunks(adapter, 3)) in searchsets
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #694 

This eliminates the exponential algorithm. This does not affect the speed of KmerFinder because it is oblivious to the number of patterns searched, as long as their combined length is smaller than a machine word.
The only disadvantage is an increase in the number of false positives:

before:
```
kmer    start   stop    considered sites        hit chance by random sequence (%)
AGA             -3      None    1       1.56
AGAT            -4      None    1       0.39
AGATC           -19     None    15      1.45
GGAAG           -19     None    15      1.45
AGATCGG         -33     None    27      0.16
AAGAGCA         -33     None    27      0.16
AACTCCAG        -33     None    26      0.04
CACGTCTG        -33     None    26      0.04
CACGTC          -29     None    24      0.58
AGATCGGA        0       None    143     0.22
CGTCTGAAC       0       None    142     0.05
TCCAGTCA        0       None    143     0.22
AGAGCACA        0       None    143     0.22
Chance for profile hit by random sequence: 6.39%

Percentage possible adapters: 0.1595648
```
After:
```
kmer    start   stop    considered sites        hit chance by random sequence (%)
AGA             -3      None    1       1.56
AGAT            -4      None    1       0.39
AGATC           -19     None    15      1.45
GGAAG           -19     None    15      1.45
AGATCGG         -29     None    23      0.14
CACGTC          -29     None    24      0.58
AAGAGCA         -29     None    23      0.14
CGTCTGA         -33     None    27      0.16
ACTCCAG         -33     None    27      0.16
AGATCGGA        -33     None    26      0.04
AGAGCACA        -33     None    26      0.04
GTCTGAAC        0       None    143     0.22
AGATCGGAA       0       None    142     0.05
TCCAGTCA        0       None    143     0.22
GAGCACAC        0       None    143     0.22
Chance for profile hit by random sequence: 6.65%

Percentage possible adapters: 0.163504
```

The older algorithm arranged the kmers so it required a minimal amount to proof the non-presence of the adapter. This reduced the number of false positives. As is visible, the estimated random hit chance is up 0.26 percentage points and the actual hit rate 0.40 percentage points (the percentage on the last line should be 'fraction', this is already adressed in the code by displaying a proper percentage, but this is still from old runs.). 
In practice this means alignment is run for nothing for 1 in 250 reads more than with the old algorithm. I think this is acceptable.

The kmer search set construction code can probably be simplified and refactored further but this is the best I can do for now on a limited time budget.