### PR TITLE
Speedup expected_errors by using a lookup table

### DIFF
--- a/src/cutadapt/qualtrim.pyx
+++ b/src/cutadapt/qualtrim.pyx
@@ -147,7 +147,7 @@ def poly_a_trim_index(str s):
 # calculation every time.
 cdef double[94]  QUAL_TO_ERROR_RATE = [10 ** (-q / 10) for q in range(94)]
 
-def expected_errors(str qualities, int base=33):
+def expected_errors(str qualities, uint8_t base=33):
     """
     Return the number of expected errors (as double) from a read’s
     qualities.
@@ -161,12 +161,14 @@ def expected_errors(str qualities, int base=33):
         raise ValueError(f"Quality string contains non-ASCII values: {qualities}")
     cdef:
         size_t i
+        uint8_t phred, q
         uint8_t *quals = <uint8_t *>PyUnicode_DATA(qualities)
         size_t qual_length = PyUnicode_GET_LENGTH(qualities)
         double e = 0.0
 
     for i in range(qual_length):
-        q = quals[i] - base
+        phred = quals[i]
+        q = phred - base
         if q > 93:
             raise ValueError(f"Not a valid phred value {q} for character {ord(q)}")
         e += QUAL_TO_ERROR_RATE[q]


### PR DESCRIPTION
Also includes a check if every phred score is in fact a valid phred score. By assigning the phreds to a uint8_t array, the `quals[i] - base` calculation is unsigned, and thus the result will always be positive. If the invalid character is a phred lower than 33, say 10, then it will map to 245. As a result we can check all phreds with only one check: are they higher than 93?

A lookup table is much faster than the expensive exponent calculations for floats. Especially since the lookup table will fit easily in L1-cache, the lookup time is at most ~3-4 clock cycles, which is hard to beat using arithmetic. 