### PR TITLE
Add an option for maximum average error rate (--max-aer)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,13 @@
 Changelog
 =========
 
-v4.5-dev
------------------
-+ Add a ``--max-average-error-rate`` / ``--max-aer`` option to add a filter
-  that checks if the maximum expected errors divided by length is above a
-  certain threshold. It works the same as ``--max-expected-errors`` except that
-  it is better suited to deal with reads of varying length.
+development version
+-------------------
+* Add a ``--max-average-error-rate``/``--max-aer`` option to add a filter
+  that checks if the number of expected errors divided by  read length is above a
+  certain threshold. This expected errors are calculated the same as in
+  ``--max-expected-errors`` and dividing by read length helps for reads that
+  have varying lengths.
 
 v4.4 (2023-04-28)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+v4.5-dev
+-----------------
++ Add a ``--max-average-error-rate`` / ``--max-aer`` option to add a filter
+  that checks if the maximum expected errors divided by length is above a
+  certain threshold. It works the same as ``--max-expected-errors`` except that
+  it is better suited to deal with reads of varying length.
+
 v4.4 (2023-04-28)
 -----------------
 

--- a/doc/algorithms.rst
+++ b/doc/algorithms.rst
@@ -207,3 +207,9 @@ computed from the quality scores as described in the USEARCH paper by
 The USEARCH manual page `has a lot more background on expected
 errors <https://www.drive5.com/usearch/manual/exp_errs.html>`_ and how to choose
 a threshold.
+
+The ``--max-average-error-rate`` (short version: ``--max-aer``) option works
+similarly but divides the expected errors by the length of the read.
+The resulting fraction is then used to filter the read. This is especially
+helpful on reads that have wildly varying read length, such as those coming
+from nanopore sequencing.

--- a/doc/algorithms.rst
+++ b/doc/algorithms.rst
@@ -211,5 +211,5 @@ a threshold.
 The ``--max-average-error-rate`` (short version: ``--max-aer``) option works
 similarly but divides the expected errors by the length of the read.
 The resulting fraction is then used to filter the read. This is especially
-helpful on reads that have wildly varying read length, such as those coming
+helpful on reads that have highly varying read length, such as those coming
 from nanopore sequencing.

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -1418,9 +1418,9 @@ reads. They always discard those reads for which the filtering criterion applies
 
 
 ``--max-average-error-rate ERROR_RATE`` or ``--max-aer``
-    Similar to ``--max-expected-errors`` except that the number of expected
-    errors is divided by the read length and the expected input is a fraction
-    between 0.0 and 1.0.
+    Discard reads with more than ERROR_RATE average expected errors
+    (total expected errors divided by the read length). ERROR_RATE must
+    be between 0.0 and 1.0.
 
 ``--discard-casava``
     Discard reads that did not pass CASAVA filtering. Illumina’s CASAVA pipeline in

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -1416,6 +1416,12 @@ reads. They always discard those reads for which the filtering criterion applies
 ``--max-expected-errors ERRORS`` or ``--max-ee ERRORS``
     Discard reads with more than ERRORS :ref:`expected errors <expected-errors>`.
 
+
+``--max-average-error-rate ERROR_RATE`` or ``--max-aer``
+    Similar to ``--max-expected-errors`` except that the number of expected
+    errors is divided by the read length and the expected input is a fraction
+    between 0.0 and 1.0.
+
 ``--discard-casava``
     Discard reads that did not pass CASAVA filtering. Illumina’s CASAVA pipeline in
     version 1.8 adds an *is_filtered* header field to each read. Specifying this

--- a/src/cutadapt/cli.py
+++ b/src/cutadapt/cli.py
@@ -296,10 +296,10 @@ def get_argument_parser() -> ArgumentParser:
         metavar="ERRORS",
         help="Discard reads whose expected number of errors (computed "
             "from quality values) exceeds ERRORS.")
-    group.add_argument("--max-average-error-rate", "--max-er", type=float, default=None,
+    group.add_argument("--max-average-error-rate", "--max-aer", type=float, default=None,
         metavar="ERROR_RATE",
-        help="Discard reads whose expected average error rate (computed "
-             "from quality values divided by length) exceeds ERROR_RATE")
+        help="as --max-expected-errors (see above), but divided by length to "
+             "account for reads of varying length.")
     group.add_argument("--discard-trimmed", "--discard", action='store_true', default=False,
         help="Discard reads that contain an adapter. Use also -O to avoid "
             "discarding too many randomly matching reads.")

--- a/src/cutadapt/cli.py
+++ b/src/cutadapt/cli.py
@@ -296,6 +296,10 @@ def get_argument_parser() -> ArgumentParser:
         metavar="ERRORS",
         help="Discard reads whose expected number of errors (computed "
             "from quality values) exceeds ERRORS.")
+    group.add_argument("--max-average-error-rate", "--max-er", type=float, default=None,
+        metavar="ERROR_RATE",
+        help="Discard reads whose expected average error rate (computed "
+             "from quality values divided by length) exceeds ERROR_RATE")
     group.add_argument("--discard-trimmed", "--discard", action='store_true', default=False,
         help="Discard reads that contain an adapter. Use also -O to avoid "
             "discarding too many randomly matching reads.")
@@ -904,6 +908,7 @@ class PipelineMaker:
                 setattr(pipeline, attr, lengths)
         pipeline.max_n = self.args.max_n
         pipeline.max_expected_errors = self.args.max_expected_errors
+        pipeline.max_average_error_rate = self.args.max_average_error_rate
         pipeline.discard_casava = self.args.discard_casava
         pipeline.discard_trimmed = self.args.discard_trimmed
         pipeline.discard_untrimmed = self.args.discard_untrimmed

--- a/src/cutadapt/pipeline.py
+++ b/src/cutadapt/pipeline.py
@@ -30,6 +30,7 @@ from .predicates import (
     TooLong,
     TooManyN,
     TooManyExpectedErrors,
+    TooHighAverageErrorRate,
     CasavaFiltered,
     DiscardTrimmed,
 )
@@ -72,6 +73,7 @@ class Pipeline(ABC):
         self._maximum_length = None
         self.max_n = None
         self.max_expected_errors = None
+        self.max_average_error_rate = None
         self.discard_casava = False
         self.discard_trimmed = False
         self.discard_untrimmed = False
@@ -147,6 +149,15 @@ class Pipeline(ABC):
                 )
             else:
                 f1 = f2 = TooManyExpectedErrors(self.max_expected_errors)
+                self._steps.append(self._make_filter(f1, f2, None))
+
+        if self.max_average_error_rate is not None:
+            if not self._reader.delivers_qualities:
+                logger.warning(
+                    "Ignoring option --max-er because input does not contain quality values"
+                )
+            else:
+                f1 = f2 = TooHighAverageErrorRate(self.max_average_error_rate)
                 self._steps.append(self._make_filter(f1, f2, None))
 
         if self.discard_casava:

--- a/src/cutadapt/predicates.py
+++ b/src/cutadapt/predicates.py
@@ -81,7 +81,7 @@ class TooHighAverageErrorRate(Predicate):
     def __init__(self, max_error_rate: float):
         if not 0.0 < max_error_rate < 1.0:
             raise ValueError(
-                f"max_error_rate must be between 0.0 and 1.0, " f"got {max_error_rate}."
+                f"max_error_rate must be between 0.0 and 1.0, got {max_error_rate}."
             )
         self.max_error_rate = max_error_rate
 

--- a/src/cutadapt/predicates.py
+++ b/src/cutadapt/predicates.py
@@ -71,6 +71,27 @@ class TooManyExpectedErrors(Predicate):
         return expected_errors(read.qualities) > self.max_errors
 
 
+class TooHighAverageErrorRate(Predicate):
+    """
+    Select reads that have an average error rate above the threshold.
+    This works better than TooManyExpectedErrors for reads that are expected to
+    have varying lengths, such as for long read sequencing technologies.
+    """
+
+    def __init__(self, max_error_rate: float):
+        if not 0.0 < max_error_rate < 1.0:
+            raise ValueError(
+                f"max_error_rate must be between 0.0 and 1.0, " f"got {max_error_rate}."
+            )
+        self.max_error_rate = max_error_rate
+
+    def __repr__(self):
+        return f"TooHighAverageErrorRate(max_error_rate={self.max_error_rate}"
+
+    def test(self, read, info: ModificationInfo):
+        return (expected_errors(read.qualities) / len(read)) > self.max_error_rate
+
+
 class TooManyN(Predicate):
     """
     Select reads that have too many 'N' bases.

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -21,7 +21,6 @@ from cutadapt.steps import PairedEndFilter
     ],
 )
 def test_too_many_n(seq, count, expected):
-    # third parameter is True if read should be Trueed
     predicate = TooManyN(count=count)
     _seq = SequenceRecord("read1", seq, qualities="#" * len(seq))
     assert predicate.test(_seq, []) == expected
@@ -67,7 +66,6 @@ def test_invalid_pair_filter_mode():
     ],
 )
 def test_too_high_average_error_rate(quals, rate, expected):
-    # third parameter is True if read should be Trueed
     predicate = TooHighAverageErrorRate(rate)
     _seq = SequenceRecord("read1", "A" * len(quals), qualities=quals)
     assert predicate.test(_seq, []) == expected


### PR DESCRIPTION
I did some tests on GM24385_1.fastq.gz which is one of the nanopore GIAB samples. It has about 3 million records ranging from 3bp to over a million bp. 
`--max-ee` is unsuitable for this use case. A max-ee of 3 would be absolute garbage for the 3bp reads and stellar never seen before quality for the 1 million bp reads.

This pr adds a `--max-average-error-rate`/`--max-aer` option to alleviate this problem. Using a `--max-aer 0.1` option for instance to filter out the very worst long read sequencing reads seems like a decent practice.

I will be off until coming tuesday, so I won't be able to respond as promptly as I usually do. I hope you will consider this PR as it will make using cutadapt for long-read sequencing much more viable.