### PR TITLE
Make expected errors use doubles again for increased precision

### DIFF
--- a/src/cutadapt/expected_errors.h
+++ b/src/cutadapt/expected_errors.h
@@ -117,46 +117,54 @@ expected_errors_from_phreds(const uint8_t *phreds, size_t phreds_length, uint8_t
         if (_mm_movemask_epi8(illegal_phreds)) {
             return -1.0;
         }
-        __m128d loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[0] - base],
-            SCORE_TO_ERROR_RATE[cursor[1] - base]
+        /* By explicitly setting multiple accumulators, the processor 
+           can perform out of order execution for increased speed 
+            See also: https://stackoverflow.com/a/36591776/16437839   
+        */
+        __m128d accumulator1 = _mm_add_pd(
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[0] - base],
+                SCORE_TO_ERROR_RATE[cursor[1] - base]
+            ),
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[2] - base],
+                SCORE_TO_ERROR_RATE[cursor[3] - base]
+            )
         );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[2] - base],
-            SCORE_TO_ERROR_RATE[cursor[3] - base]
+        __m128d accumulator2 = _mm_add_pd(
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[4] - base],
+                SCORE_TO_ERROR_RATE[cursor[5] - base]
+            ),
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[6] - base],
+                SCORE_TO_ERROR_RATE[cursor[7] - base]
+            )
         );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[4] - base],
-            SCORE_TO_ERROR_RATE[cursor[5] - base]
+        __m128d accumulator3 = _mm_add_pd(
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[8] - base],
+                SCORE_TO_ERROR_RATE[cursor[9] - base]
+            ),
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[10] - base],
+                SCORE_TO_ERROR_RATE[cursor[11] - base]
+            )
         );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[6] - base],
-            SCORE_TO_ERROR_RATE[cursor[7] - base]
-        );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[8] - base],
-            SCORE_TO_ERROR_RATE[cursor[9] - base]
-        );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[10] - base],
-            SCORE_TO_ERROR_RATE[cursor[11] - base]
-        );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[12] - base],
-            SCORE_TO_ERROR_RATE[cursor[13] - base]
-        );
-        accumulator = _mm_add_pd(accumulator, loader);
-        loader = _mm_set_pd(
-            SCORE_TO_ERROR_RATE[cursor[14] - base],
-            SCORE_TO_ERROR_RATE[cursor[15] - base]
-        );
-        accumulator = _mm_add_pd(accumulator, loader);
+        __m128d accumulator4 = _mm_add_pd(
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[12] - base],
+                SCORE_TO_ERROR_RATE[cursor[13] - base]
+            ),
+            _mm_set_pd(
+                SCORE_TO_ERROR_RATE[cursor[14] - base],
+                SCORE_TO_ERROR_RATE[cursor[15] - base]
+            )
+        ); 
+        accumulator = _mm_add_pd(accumulator, accumulator1);
+        accumulator = _mm_add_pd(accumulator, accumulator2);
+        accumulator = _mm_add_pd(accumulator, accumulator3);
+        accumulator = _mm_add_pd(accumulator, accumulator4);
         cursor += sizeof(__m128i);
     }
     double double_store[2];

--- a/src/cutadapt/qualtrim.pyx
+++ b/src/cutadapt/qualtrim.pyx
@@ -159,7 +159,7 @@ def expected_errors(str qualities, uint8_t base=33):
     cdef:
         uint8_t *quals = <uint8_t *>PyUnicode_DATA(qualities)
         size_t qual_length = PyUnicode_GET_LENGTH(qualities)
-        float e = expected_errors_from_phreds(quals, qual_length, base)
+        double e = expected_errors_from_phreds(quals, qual_length, base)
 
     if e < 0.0:
         for q in qualities:

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -62,7 +62,7 @@ def test_invalid_pair_filter_mode():
         (chr(43) * 3 + chr(33), 0.1, True),  # 3 * 0.1 + 1
         (chr(43) * 3 + chr(33), 0.33, False),  # 3 * 0.1 + 1
         (chr(43) * 3 + chr(33), 0.32, True),  # 3 * 0.1 + 1
-        (chr(103) * 9 + chr(33), 0.1, True),  # 9 * 10^-7 + 1
+        (chr(126) * 9 + chr(33), 0.1, True),  # 9 * 10^-9.3 + 1
     ],
 )
 def test_too_high_average_error_rate(quals, rate, expected):


### PR DESCRIPTION
Hi Marcel,

It seems I made an error of judgement in #726. In that thread I state that single precision numbers is enough. That statement is incorrect, or a half-truth.

Since phred scores are between 0 and 93 they have only two significant decimal digits. Two decimal digits means 100 units, so that can be approached by a floating point number that has a significand of at least 7 bits significance. Floating point has 23 bits, so that is ample.

However this does not properly look at the calculation required to add two phred units. Single precision numbers have a 23-bit significand meaning that they can represent numbers that are 2^23 ~=  8 million units apart. Adding a phred of 0 to a phred of 70 (10 million units) is therefore barely possible. Adding a phred of 93 to a phred of 0 simply does not register. That means that floating point numbers can never be sufficient as an intermediate when summing large numbers of phred probabilities as some phreds simply get lost.

This is still true when looking at more practical use cases. In practice the highest illumina phred is 37. So 10**-3.7 verses 1.0 that is roughly 13 bits. Combined with a read length of 151 (9 bits) that makes for 22bits of precision needed to ensure all probabilities. Float has that. Going beyond illumina to nanopore however it immediately becomes clear that there aren't enough bits as nanopore can reach sizes up to 2 million (21 bits) and has a phred range between 0 and 50ish (17 bits).

A double precision number with a 53-bit significand is ample however for most practical use cases. I have sharpened the test case again so that it is correct even when using the extremes of the phred range.

Speed does not mean anything when the result is not correct. Luckily the vectorization can be kept and expected errors is still vectorized and still faster than 4.4.  

