### PR TITLE
Follow best practices for pointer aliasing in alignment inner loop.

### DIFF
--- a/src/cutadapt/_align.pyx
+++ b/src/cutadapt/_align.pyx
@@ -416,8 +416,8 @@ cdef class Aligner:
             # To access the diagonal cell to the upper left,
             # we store it here before overwriting it.
             _Entry diag_entry
-            _Entry current_cell
-            _Entry previous_cell
+            _Entry current_entry
+            _Entry previous_entry
 
         with nogil:
             # iterate over columns
@@ -443,11 +443,11 @@ cdef class Aligner:
                         score = diag_entry.score + match_score
                     else:
                         # Characters do not match.
-                        current_cell = column[i]
-                        previous_cell = column[i-1]
+                        current_entry = column[i]
+                        previous_entry = column[i-1]
                         cost_diag = diag_entry.cost + 1
-                        cost_deletion = current_cell.cost + deletion_cost
-                        cost_insertion = previous_cell.cost + insertion_cost
+                        cost_deletion = current_entry.cost + deletion_cost
+                        cost_insertion = previous_entry.cost + insertion_cost
 
                         if cost_diag <= cost_deletion and cost_diag <= cost_insertion:
                             # MISMATCH
@@ -457,15 +457,15 @@ cdef class Aligner:
                         elif cost_insertion <= cost_deletion:
                             # INSERTION
                             cost = cost_insertion
-                            origin = previous_cell.origin
+                            origin = previous_entry.origin
                             # penalize insertions slightly
-                            score = previous_cell.score + insertion_score
+                            score = previous_entry.score + insertion_score
                         else:
                             # DELETION
                             cost = cost_deletion
-                            origin = current_cell.origin
+                            origin = current_entry.origin
                             # penalize deletions slightly
-                            score = current_cell.score + deletion_score
+                            score = current_entry.score + deletion_score
 
                     # Remember the current cell for next iteration
                     diag_entry = column[i]

--- a/src/cutadapt/_align.pyx
+++ b/src/cutadapt/_align.pyx
@@ -406,6 +406,12 @@ cdef class Aligner:
             int insertion_cost_increment = self._insertion_cost if not self.start_in_query else 0
             bint characters_equal
             bint is_acceptable
+            int insertion_cost = self._insertion_cost
+            int deletion_cost = self._deletion_cost
+            int match_score = self._match_score
+            int mismatch_score = self._mismatch_score
+            int insertion_score = self._insertion_score
+            int deletion_score = self._deletion_score
             # We keep only a single column of the DP matrix in memory.
             # To access the diagonal cell to the upper left,
             # we store it here before overwriting it.
@@ -432,30 +438,30 @@ cdef class Aligner:
                         origin = diag_entry.origin
                         # Among the optimal alignments whose edit distance is within the
                         # maximum allowed error rate, we prefer those with maximal score.
-                        score = diag_entry.score + self._match_score
+                        score = diag_entry.score + match_score
                     else:
                         # Characters do not match.
                         cost_diag = diag_entry.cost + 1
-                        cost_deletion = column[i].cost + self._deletion_cost
-                        cost_insertion = column[i-1].cost + self._insertion_cost
+                        cost_deletion = column[i].cost + deletion_cost
+                        cost_insertion = column[i-1].cost + insertion_cost
 
                         if cost_diag <= cost_deletion and cost_diag <= cost_insertion:
                             # MISMATCH
                             cost = cost_diag
                             origin = diag_entry.origin
-                            score = diag_entry.score + self._mismatch_score
+                            score = diag_entry.score + mismatch_score
                         elif cost_insertion <= cost_deletion:
                             # INSERTION
                             cost = cost_insertion
                             origin = column[i-1].origin
                             # penalize insertions slightly
-                            score = column[i-1].score + self._insertion_score
+                            score = column[i-1].score + insertion_score
                         else:
                             # DELETION
                             cost = cost_deletion
                             origin = column[i].origin
                             # penalize deletions slightly
-                            score = column[i].score + self._deletion_score
+                            score = column[i].score + deletion_score
 
                     # Remember the current cell for next iteration
                     diag_entry = column[i]


### PR DESCRIPTION
Hi a very simple PR. Currently the alignment inner loop contains a lot of pointer lookups. Therefore the compiler will always take the safe road. It cannot be sure if those pointers have been updated in the meantime.

This PR puts lookups that are guaranteed to stay the same in a certain scope in their own variable. This allows the compiler to do some nice optimizations (if it is able to spot some). 

I did take a look at the resulting assembler. Unfortunately I cannot provide any insights why as this might be faster.

The results:
before:
```
Benchmark 1: cutadapt -e 0.2 -a GCAATACGTAACTGAACGAAGTACAGG ~/test/nanopore_10000reads.fastq -o /dev/null
  Time (mean ± σ):      4.643 s ±  0.063 s    [User: 4.567 s, System: 0.073 s]
  Range (min … max):    4.571 s …  4.744 s    5 runs
```

After:
```
Benchmark 1: cutadapt -e 0.2 -a GCAATACGTAACTGAACGAAGTACAGG ~/test/nanopore_10000reads.fastq -o /dev/null
  Time (mean ± σ):      3.762 s ±  0.010 s    [User: 3.714 s, System: 0.046 s]
  Range (min … max):    3.748 s …  3.772 s    5 runs
```

I took nanopore with high error rate because otherwise the kmer finder does most of the heavy lifting. By setting error at 0.2 it is looking for 4-mers and 5-mers which almost guarantees invoking the aligner for every read.