### PR TITLE
Add admonition about info-file w/r/t paired end mode

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -721,9 +721,9 @@ input read, but in the following cases, multiple rows may be output:
 A row is written for *all* input reads, even those that are discarded
 from the final FASTA/FASTQ output due to filtering options.
 
-.. note:: Paired-end reads not supported.
-   The info file currently does not contain any info about read 2, when
-   cutadapt is run in paired-end mode.
+.. note:: Paired-end reads are not supported.
+   The info file currently does not contain any info about read 2 when
+   Cutadapt is run in paired-end mode.
 
 Which fields are output in each row depends on whether an adapter match was
 found in the read or not.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -721,6 +721,10 @@ input read, but in the following cases, multiple rows may be output:
 A row is written for *all* input reads, even those that are discarded
 from the final FASTA/FASTQ output due to filtering options.
 
+.. note:: Paired-end reads not supported.
+   The info file currently does not contain any info about read 2, when
+   cutadapt is run in paired-end mode.
+
 Which fields are output in each row depends on whether an adapter match was
 found in the read or not.
 


### PR DESCRIPTION
I found issue https://github.com/marcelm/cutadapt/issues/302 that makes clear that `--info-file` does not currently fully support paired-end mode.



I suggest adding a little admonition to the docs to make this clear.  (Apologies if this information already exists somewhere in the docs -- I did a quick search but I couldn't find any mentions, aside from the above issue.)