### PR TITLE
Remote File Support for input files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dynamic = ["version"]
 dependencies = [
     "dnaio >= 1.2.0",
     "xopen >= 1.6.0",
+    "smart_open >= 6.4.0",
 ]
 
 [project.urls]

--- a/src/cutadapt/runners.py
+++ b/src/cutadapt/runners.py
@@ -15,7 +15,7 @@ from cutadapt.files import (
     InputFiles,
     OutputFiles,
     InputPaths,
-    xopen_rb_raise_limit,
+    open_rb,
     detect_file_format,
     FileFormat,
     ProxyWriter,
@@ -91,7 +91,7 @@ class ReaderProcess(mpctx_Process):
         try:
             with ExitStack() as stack:
                 files = [
-                    stack.enter_context(xopen_rb_raise_limit(path))
+                    stack.enter_context(open_rb(path))
                     for path in self._paths
                 ]
                 file_format = detect_file_format(files[0])

--- a/src/cutadapt/runners.py
+++ b/src/cutadapt/runners.py
@@ -15,7 +15,7 @@ from cutadapt.files import (
     InputFiles,
     OutputFiles,
     InputPaths,
-    open_rb,
+    xopen_rb_raise_limit,
     detect_file_format,
     FileFormat,
     ProxyWriter,
@@ -91,7 +91,7 @@ class ReaderProcess(mpctx_Process):
         try:
             with ExitStack() as stack:
                 files = [
-                    stack.enter_context(open_rb(path))
+                    stack.enter_context(xopen_rb_raise_limit(path))
                     for path in self._paths
                 ]
                 file_format = detect_file_format(files[0])

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 
-from cutadapt.files import ProxyTextFile, ProxyRecordWriter, OutputFiles
+from cutadapt.files import ProxyTextFile, ProxyRecordWriter, OutputFiles,open_rb
 from dnaio import SequenceRecord
 
 
@@ -125,6 +125,28 @@ class TestOutputFiles:
         o.close()
         assert path.read_text() == "@r\nAACC\n+\n####\n@r\nGGTT\n+\n####\n"
 
+
+def test_open_rb_local_file(tmp_path):
+        
+    # Create a local file
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("Hello, World!")
+    # Test opening a local file
+    file = open_rb(str(file_path))
+    assert file.read() == b"Hello, World!"
+    file.close()
+
+def test_open_rb_remote_file():
+    # Test opening a remote file over https
+    file = open_rb("https://raw.githubusercontent.com/marcelm/cutadapt/main/tests/data/454.fa")
+    assert file.readline() == b">000163_1255_2627 length=52 uaccno=E0R4ISW01DCIQD\n"
+    file.close()
+
+def test_open_rb_s3_file():
+    # Test opening a remote file on s3 
+    file = open_rb("s3://platinum-genomes/2017-1.0/md5sum.txt")
+    assert file.readline() == b"2e6aa26b42283bbbc4ca03686f427dc2  ./hg38/small_variants/ConfidentRegions.bed.gz\n"
+    file.close()
     # - test force fasta
     # - test qualities
     # - test proxied

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,7 +1,12 @@
 import os
 import pickle
 
-from cutadapt.files import ProxyTextFile, ProxyRecordWriter, OutputFiles,open_rb
+from cutadapt.files import (
+    ProxyTextFile,
+    ProxyRecordWriter,
+    OutputFiles,
+    xopen_rb_raise_limit,
+)
 from dnaio import SequenceRecord
 
 
@@ -127,25 +132,32 @@ class TestOutputFiles:
 
 
 def test_open_rb_local_file(tmp_path):
-        
+
     # Create a local file
     file_path = tmp_path / "test.txt"
     file_path.write_text("Hello, World!")
     # Test opening a local file
-    file = open_rb(str(file_path))
+    file = xopen_rb_raise_limit(str(file_path))
     assert file.read() == b"Hello, World!"
     file.close()
 
+
 def test_open_rb_remote_file():
     # Test opening a remote file over https
-    file = open_rb("https://raw.githubusercontent.com/marcelm/cutadapt/main/tests/data/454.fa")
+    file = xopen_rb_raise_limit(
+        "https://raw.githubusercontent.com/marcelm/cutadapt/main/tests/data/454.fa"
+    )
     assert file.readline() == b">000163_1255_2627 length=52 uaccno=E0R4ISW01DCIQD\n"
     file.close()
 
+
 def test_open_rb_s3_file():
-    # Test opening a remote file on s3 
-    file = open_rb("s3://platinum-genomes/2017-1.0/md5sum.txt")
-    assert file.readline() == b"2e6aa26b42283bbbc4ca03686f427dc2  ./hg38/small_variants/ConfidentRegions.bed.gz\n"
+    # Test opening a remote file on s3
+    file = xopen_rb_raise_limit("s3://platinum-genomes/2017-1.0/md5sum.txt")
+    assert (
+        file.readline()
+        == b"2e6aa26b42283bbbc4ca03686f427dc2  ./hg38/small_variants/ConfidentRegions.bed.gz\n"
+    )
     file.close()
     # - test force fasta
     # - test qualities


### PR DESCRIPTION
I've added support for remote files (s3, gcs, ftp, http(s)) as input files. 

- It's based on redirecting file-opening to the smart_open library, and had minimal impact on the code. 

- Tests have been added and were passed (for https and s3).

- I've tried to same for output files, but the gzip-support of smart_open is very, very slow when tested on s3. So I removed that again.  