### PR TITLE
Fix bug in report.py when dealing with empty list

### DIFF
--- a/src/cutadapt/report.py
+++ b/src/cutadapt/report.py
@@ -280,7 +280,7 @@ class Statistics:
                     error_rate=end_statistics.max_error_rate,
                 ).lengths()
             else:
-                eranges = None
+                eranges = []
             base_stats = AdjacentBaseStatistics(end_statistics.adjacent_bases)
             trimmed_lengths = [
                 make_line(


### PR DESCRIPTION
cutseq report this error when `eranges` is None.

```
  File ".micromamba/lib/python3.12/site-packages/cutadapt/report.py", line 246, in as_json
    self._adapter_statistics_as_json(
  File ".micromamba/lib/python3.12/site-packages/cutadapt/report.py", line 302, in _adapter_statistics_as_json
    "error_lengths": make_line(eranges),
                     ^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```
