### PR TITLE
Do not report a match for ambiguous sequences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 development version
 -------------------
 
+This release increases the major version number because results when
+demultiplexing may change with this release.
+
+* :pr:`827`: When matching multiple adapters (typically when demultiplexing
+  using barcodes), Cutadapt now no longer assigns ambiguous matches to one
+  of the adapters/barcodes.
 * :issue:`808`: Made gzip compression level 1 the default, which improves
   runtime significantly in many cases. (Compressing the output is often a
   bottleneck when using multiple threads.) Output files will be larger, but because

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -1915,6 +1915,7 @@ To demultiplex this type of data, the
 
 
 .. _speed-up-demultiplexing:
+.. _adapter-indexing:
 
 Speeding up demultiplexing/adapter indexing
 -------------------------------------------
@@ -1960,6 +1961,24 @@ Cutadapt’s output::
 
 .. versionadded:: 5.0
    An index is created up to three (instead of two) allowed errors.
+
+Ambiguous sequences
+~~~~~~~~~~~~~~~~~~~
+
+When :ref:`an index is created for multiple anchored adapters <adapter-indexing>`, Cutadapt checks
+whether there are any possible input sequences that lead to ambiguous matches, that is, which
+would match two or more adapter sequences equally well.
+If there are ambiguous sequences, Cutadapt prints a warning like this::
+
+    WARNING: The adapters are too similar. When creating the index, 31 ambiguous sequences were found that cannot be assigned uniquely.
+    WARNING: For example, 'TAGTGCTTGA', when found in a read, would result in 10 matches for both bc3 'TAGTGCTTGA' and bc11 'TAGTGCTTGA'
+    WARNING: Reads with ambiguous sequence will *not* be trimmed.
+
+If you use ``-no-index``, Cutadapt will not print this warning and instead assign ambiguous reads
+to the first of the adapters that match equally well.
+
+.. versionadded:: 5.0
+   Ambiguous sequences were not handled specially in earlier versions.
 
 Demultiplexing paired-end reads in mixed orientation
 ----------------------------------------------------

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -509,7 +509,7 @@ def test_indexed_very_similar(caplog):
             PrefixAdapter("GAAG", max_errors=1, indels=False),
         ]
     )
-    assert "cannot be assigned uniquely" in caplog.text
+    assert "ambiguous sequences" in caplog.text
 
 
 def test_indexed_too_high_k():
@@ -580,6 +580,26 @@ def test_indexed_prefix_adapters_with_n_collision(sequence):
 
     assert isinstance(result, RemoveBeforeMatch)
     assert result.adapter is a2
+
+
+def test_indexed_prefix_adapters_ignore_ambiguous_matches():
+    a1 = PrefixAdapter("AAAAA", max_errors=1, indels=False)
+    a2 = PrefixAdapter("TTAAA", max_errors=1, indels=False)
+    ipa = IndexedPrefixAdapters([a1, a2])
+
+    result = ipa.match_to("ATAAA")
+
+    assert result is None
+
+
+def test_indexed_prefix_adapters_ignore_ambiguous_matches_with_indels():
+    a1 = PrefixAdapter("AGTACGT", max_errors=1, indels=True)
+    a2 = PrefixAdapter("ACGTAGT", max_errors=1, indels=True)
+    ipa = IndexedPrefixAdapters([a1, a2])
+
+    result = ipa.match_to("ACGTACGT")
+
+    assert result is None
 
 
 def test_inosine_wildcard():


### PR DESCRIPTION
This is a backwards-incompatible change, and therefore the version number will be bumped to 5.0.

This only applies when an index is used.

At index creation time, ambiguous sequences (those that would match two or more adapters equally well), are now *removed* from the index. That is, when they are encountered in a read, they will not be assigned to any adapter.

The intention is to reduce bias because we previously would report a match to one of the adapters (but which one was more or less randomly determined at index creation time).