### PR TITLE
Instructions for Homebrew on macOS

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -141,6 +141,15 @@ When running Cutadapt this way, you will need to remember to write
 ``py -m cutadapt`` instead of just ``cutadapt``.
 
 
+macOS with Homebrew
+------------------------
+
+Cutadapt can be installed on macOS with the following command::
+
+    brew install cutadapt
+    cutadapt --version
+
+
 FreeBSD ports and pkgsrc
 ------------------------
 


### PR DESCRIPTION
Cutadapt is now [available](https://github.com/Homebrew/homebrew-core/commit/685392629bec8f79860e87738d8d4a88a983717e) to install via [Homebrew](https://brew.sh).